### PR TITLE
Cache consistency tests and validation

### DIFF
--- a/platform/kube/client.go
+++ b/platform/kube/client.go
@@ -48,8 +48,10 @@ const (
 	IstioResourceVersion = "v1"
 )
 
-// Client Kubernetes bindings for the manager:
+// Client provides state-less Kubernetes bindings for the manager:
 // - configuration objects are stored as third-party resources
+// - dynamic REST client is configured to use third-party resources
+// - static client exposes Kubernetes API
 type Client struct {
 	mapping model.KindMap
 	client  *kubernetes.Clientset

--- a/platform/kube/controller.go
+++ b/platform/kube/controller.go
@@ -226,13 +226,13 @@ func (c *Controller) Get(key model.ConfigKey) (*model.Config, bool) {
 	return out, true
 }
 
-// Put applies operation to the remote storage only
+// Put applies operation to the remote storage ONLY
 // This implies that you might not see the effect immediately
 func (c *Controller) Put(obj *model.Config) error {
 	return c.client.Put(obj)
 }
 
-// Delete applies operation to the remote storage and local cache
+// Delete applies operation to the remote storage ONLY
 // This implies that you might not see the effect immediately
 func (c *Controller) Delete(key model.ConfigKey) error {
 	return c.client.Delete(key)

--- a/platform/kube/controller.go
+++ b/platform/kube/controller.go
@@ -23,8 +23,6 @@ import (
 
 	"istio.io/manager/model"
 
-	meta_v1 "k8s.io/client-go/pkg/apis/meta/v1"
-
 	"k8s.io/client-go/pkg/api"
 	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/pkg/runtime"
@@ -35,9 +33,8 @@ import (
 // Controller is a collection of synchronized resource watchers
 // Caches are thread-safe
 type Controller struct {
-	client      *Client
-	queue       Queue
-	controllers []*cache.Controller
+	client *Client
+	queue  Queue
 
 	kinds     map[string]cacheHandler
 	endpoints cacheHandler
@@ -45,8 +42,8 @@ type Controller struct {
 }
 
 type cacheHandler struct {
-	store   cache.Store
-	handler *chainHandler
+	informer cache.SharedIndexInformer
+	handler  *chainHandler
 }
 
 // NewController creates a new Kubernetes controller
@@ -62,7 +59,7 @@ func NewController(
 		kinds:  make(map[string]cacheHandler),
 	}
 
-	out.services = out.addWatcher(&v1.Service{}, resyncPeriod,
+	out.services = out.createInformer(&v1.Service{}, resyncPeriod,
 		func(opts v1.ListOptions) (runtime.Object, error) {
 			return client.client.Services(namespace).List(opts)
 		},
@@ -70,7 +67,7 @@ func NewController(
 			return client.client.Services(namespace).Watch(opts)
 		})
 
-	out.endpoints = out.addWatcher(&v1.Endpoints{}, resyncPeriod,
+	out.endpoints = out.createInformer(&v1.Endpoints{}, resyncPeriod,
 		func(opts v1.ListOptions) (runtime.Object, error) {
 			return client.client.Endpoints(namespace).List(opts)
 		},
@@ -80,7 +77,7 @@ func NewController(
 
 	// add stores for TRP kinds
 	for kind := range client.mapping {
-		out.kinds[kind] = out.addWatcher(&Config{}, resyncPeriod,
+		out.kinds[kind] = out.createInformer(&Config{}, resyncPeriod,
 			func(opts v1.ListOptions) (result runtime.Object, err error) {
 				result = &ConfigList{}
 				err = client.dyn.Get().
@@ -108,20 +105,24 @@ func (c *Controller) notify(obj interface{}, event int) error {
 	if !c.HasSynced() {
 		return errors.New("Waiting till full synchronization")
 	}
-	log.Printf("%s: %#v", eventString(event), obj.(runtime.Object).GetObjectKind())
+	k, _ := keyFunc(obj)
+	log.Printf("%s: %#v", eventString(event), k)
 	return nil
 }
 
-func (c *Controller) addWatcher(
+func (c *Controller) createInformer(
 	o runtime.Object,
 	resyncPeriod time.Duration,
 	lf cache.ListFunc,
 	wf cache.WatchFunc) cacheHandler {
 	handler := &chainHandler{funcs: []Handler{c.notify}}
-	store, controller := cache.NewInformer(
-		&cache.ListWatch{ListFunc: lf, WatchFunc: wf},
-		o,
-		resyncPeriod,
+
+	// TODO: finer-grained index (perf)
+	informer := cache.NewSharedIndexInformer(
+		&cache.ListWatch{ListFunc: lf, WatchFunc: wf}, o,
+		resyncPeriod, cache.Indexers{})
+
+	err := informer.AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
 			// TODO: filtering functions to skip over un-referenced resources (perf)
 			AddFunc: func(obj interface{}) {
@@ -135,13 +136,18 @@ func (c *Controller) addWatcher(
 			DeleteFunc: func(obj interface{}) {
 				c.queue.Push(Task{handler: handler.apply, obj: obj, event: evDelete})
 			},
-		},
-	)
-	c.controllers = append(c.controllers, controller)
-	return cacheHandler{store: store, handler: handler}
+		})
+	if err != nil {
+		log.Print(err)
+	}
+
+	return cacheHandler{informer: informer, handler: handler}
 }
 
 // AppendHandler adds a handler for a config resource.
+// Handler executes on the single worker queue.
+// Cache view is as AT LEAST as fresh as the moment notification arrives, but
+// MAY BE more fresh (e.g. "delete" cancels "add" event in the cache).
 // Note: this method is not thread-safe, please use it before calling Run
 func (c *Controller) AppendHandler(
 	kind string,
@@ -163,9 +169,12 @@ func (c *Controller) AppendHandler(
 
 // HasSynced returns true after the initial state synchronization
 func (c *Controller) HasSynced() bool {
-	for _, ctl := range c.controllers {
-		if !ctl.HasSynced() {
-			log.Println("Controllers are syncing...")
+	if !c.services.informer.HasSynced() || !c.endpoints.informer.HasSynced() {
+		return false
+	}
+	for kind, ctl := range c.kinds {
+		if !ctl.informer.HasSynced() {
+			log.Printf("Controller %q is syncing...", kind)
 			return false
 		}
 	}
@@ -175,15 +184,23 @@ func (c *Controller) HasSynced() bool {
 // Run all controllers until a signal is received
 func (c *Controller) Run(stop chan struct{}) {
 	go c.queue.Run(stop)
-	for _, ctl := range c.controllers {
-		go ctl.Run(stop)
+	go c.services.informer.Run(stop)
+	go c.endpoints.informer.Run(stop)
+	for _, ctl := range c.kinds {
+		go ctl.informer.Run(stop)
 	}
 	<-stop
 }
 
-// key function used internally by kubernetes (here, namespace is non-empty)
-func keyFunc(namespace, name string) string {
-	return namespace + "/" + name
+// key function used internally by kubernetes
+// Typically, key is a string "namespace"/"name"
+func keyFunc(obj interface{}) (string, bool) {
+	k, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+	if err != nil {
+		log.Printf("Creating key failed: %v", err)
+		return k, false
+	}
+	return k, true
 }
 
 func (c *Controller) Get(key model.ConfigKey) (*model.Config, bool) {
@@ -192,8 +209,8 @@ func (c *Controller) Get(key model.ConfigKey) (*model.Config, bool) {
 		return nil, false
 	}
 
-	store := c.kinds[key.Kind].store
-	data, exists, err := store.GetByKey(keyFunc(key.Namespace, key.Name))
+	store := c.kinds[key.Kind].informer.GetStore()
+	data, exists, err := store.GetByKey(key.Namespace + "/" + key.Name)
 	if !exists {
 		return nil, false
 	}
@@ -209,25 +226,16 @@ func (c *Controller) Get(key model.ConfigKey) (*model.Config, bool) {
 	return out, true
 }
 
+// Put applies operation to the remote storage only
+// This implies that you might not see the effect immediately
 func (c *Controller) Put(obj *model.Config) error {
-	out, err := modelToKube(c.client.mapping, obj)
-	if err != nil {
-		return err
-	}
-	return c.kinds[obj.Kind].store.Add(out)
+	return c.client.Put(obj)
 }
 
+// Delete applies operation to the remote storage and local cache
+// This implies that you might not see the effect immediately
 func (c *Controller) Delete(key model.ConfigKey) error {
-	if err := c.client.mapping.ValidateKey(&key); err != nil {
-		return err
-	}
-	return c.kinds[key.Kind].store.Delete(
-		&Config{
-			TypeMeta: meta_v1.TypeMeta{Kind: key.Kind},
-			Metadata: api.ObjectMeta{
-				Name:      key.Name,
-				Namespace: key.Namespace,
-			}})
+	return c.client.Delete(key)
 }
 
 func (c *Controller) List(kind string, ns string) []*model.Config {
@@ -237,7 +245,7 @@ func (c *Controller) List(kind string, ns string) []*model.Config {
 
 	// TODO: use indexed cache
 	var out []*model.Config
-	for _, data := range c.kinds[kind].store.List() {
+	for _, data := range c.kinds[kind].informer.GetStore().List() {
 		config := data.(*Config)
 		if config.Metadata.Namespace == ns {
 			elt, err := kubeToModel(kind, c.client.mapping[kind], data.(*Config))
@@ -252,8 +260,12 @@ func (c *Controller) List(kind string, ns string) []*model.Config {
 }
 
 const (
-	evAdd    = 1
+	// Object is added
+	evAdd = 1
+	// Object is modified. Called when a re-list happens.
 	evUpdate = 2
+	// Object is deleted. Captures the object at the last state known, or
+	// potentially an object of type DeletedFinalStateUnknown
 	evDelete = 3
 )
 

--- a/platform/kube/minikube_test.go
+++ b/platform/kube/minikube_test.go
@@ -188,7 +188,7 @@ func TestControllerClientSync(t *testing.T) {
 
 	// check directly through the client
 	eventually(func() bool {
-		cs := cl.List(test.MockKind, ns)
+		cs := ctl.List(test.MockKind, ns)
 		os := cl.List(test.MockKind, ns)
 		log.Printf("ctl.List => Got %d, expected %d", len(cs), n)
 		log.Printf("cl.List => Got %d, expected %d", len(os), n)

--- a/platform/kube/minikube_test.go
+++ b/platform/kube/minikube_test.go
@@ -54,7 +54,7 @@ func TestThirdPartyResourcesClient(t *testing.T) {
 	ns := makeNamespace(cl.client, t)
 	defer deleteNamespace(cl.client, ns)
 
-	test.CheckMapInvariant(cl, t, ns, 10)
+	test.CheckMapInvariant(cl, t, ns, 5)
 
 	// TODO(kuat) initial watch always fails, takes time to register TPR, keep
 	// around as a work-around
@@ -73,11 +73,10 @@ func TestController(t *testing.T) {
 	stop := make(chan struct{})
 	defer close(stop)
 
-	ctl := NewController(cl, ns, 1*time.Second)
+	ctl := NewController(cl, ns, 256*time.Millisecond)
 	added, deleted := 0, 0
 	n := 5
 	ctl.AppendHandler(test.MockKind, func(c *model.Config, ev int) error {
-		log.Printf("Handler %s: %v", eventString(ev), c)
 		switch ev {
 		case evAdd:
 			if deleted != 0 {
@@ -99,7 +98,7 @@ func TestController(t *testing.T) {
 	eventually(func() bool { return added == n && deleted == n }, t)
 }
 
-func TestControllerRegistry(t *testing.T) {
+func TestControllerCacheFreshness(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	}
@@ -108,9 +107,100 @@ func TestControllerRegistry(t *testing.T) {
 	ns := makeNamespace(cl.client, t)
 	defer deleteNamespace(cl.client, ns)
 	stop := make(chan struct{})
+	ctl := NewController(cl, ns, 256*time.Millisecond)
+
+	// validate cache consistency requirement:
+	// When you receive a notification, the cache will be AT LEAST as fresh as the notification, but it MAY be more fresh.
+	ctl.AppendHandler(test.MockKind, func(c *model.Config, ev int) error {
+		elts := ctl.List(test.MockKind, ns)
+		switch ev {
+		case evAdd:
+			if len(elts) != 1 {
+				t.Errorf("Got %#v, expected %d element(s) on ADD event", elts, 1)
+			}
+			ctl.Delete(c.ConfigKey)
+		case evDelete:
+			if len(elts) != 0 {
+				t.Errorf("Got %#v, expected zero elements on DELETE event", elts)
+			}
+			close(stop)
+		}
+		return nil
+	})
+
+	go ctl.Run(stop)
+	o := test.MakeMock(0, ns)
+
+	// put followed by delete
+	if err := ctl.Put(o); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestControllerClientSync(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
+	cl := makeClient(t)
+	ns := makeNamespace(cl.client, t)
+	n := 5
+	defer deleteNamespace(cl.client, ns)
+	stop := make(chan struct{})
 	defer close(stop)
-	ctl := NewController(cl, ns, 1*time.Second)
-	test.CheckMapInvariant(ctl, t, ns, 3)
+
+	// add elements directly through client
+	for i := 0; i < n; i++ {
+		if err := cl.Put(test.MakeMock(i, ns)); err != nil {
+			t.Error(err)
+		}
+	}
+
+	// check in the controller cache
+	ctl := NewController(cl, ns, 256*time.Millisecond)
+	go ctl.Run(stop)
+	eventually(func() bool { return ctl.HasSynced() }, t)
+	os := ctl.List(test.MockKind, ns)
+	if len(os) != n {
+		t.Errorf("ctl.List => Got %d, expected %d", len(os), n)
+	}
+
+	// remove elements directly through client
+	for i := 0; i < n; i++ {
+		if err := cl.Delete(test.MakeMock(i, ns).ConfigKey); err != nil {
+			t.Error(err)
+		}
+	}
+
+	// check again in the controller cache
+	eventually(func() bool {
+		os = ctl.List(test.MockKind, ns)
+		log.Printf("ctl.List => Got %d, expected %d", len(os), 0)
+		return len(os) == 0
+	}, t)
+
+	// now add through the controller
+	for i := 0; i < n; i++ {
+		if err := ctl.Put(test.MakeMock(i, ns)); err != nil {
+			t.Error(err)
+		}
+	}
+
+	// check directly through the client
+	eventually(func() bool {
+		cs := cl.List(test.MockKind, ns)
+		os := cl.List(test.MockKind, ns)
+		log.Printf("ctl.List => Got %d, expected %d", len(cs), n)
+		log.Printf("cl.List => Got %d, expected %d", len(os), n)
+		return len(os) == n && len(cs) == n
+	}, t)
+
+	// remove elements directly through the client
+	for i := 0; i < n; i++ {
+		if err := cl.Delete(test.MakeMock(i, ns).ConfigKey); err != nil {
+			t.Error(err)
+		}
+	}
 }
 
 func eventually(f func() bool, t *testing.T) {
@@ -119,11 +209,11 @@ func eventually(f func() bool, t *testing.T) {
 		if f() {
 			return
 		}
-		t.Logf("Sleeping %v", interval)
+		log.Printf("Sleeping %v", interval)
 		time.Sleep(interval)
 		interval = 2 * interval
 	}
-	t.Fatal("Failed to satisfy function")
+	t.Errorf("Failed to satisfy function")
 }
 
 func makeClient(t *testing.T) *Client {

--- a/test/mocks.go
+++ b/test/mocks.go
@@ -104,22 +104,26 @@ func (r *MockRegistry) List(kind string, ns string) []*model.Config {
 	return out
 }
 
+func MakeMock(i int, namespace string) *model.Config {
+	return &model.Config{
+		ConfigKey: model.ConfigKey{
+			Kind:      MockKind,
+			Name:      fmt.Sprintf("%s%d", MockName, i),
+			Namespace: namespace,
+		},
+		Spec: &MockConfig{
+			Pairs: []*ConfigPair{
+				&ConfigPair{Key: "key", Value: strconv.Itoa(i)},
+			},
+		},
+	}
+}
+
 func CheckMapInvariant(r model.Registry, t *testing.T, namespace string, n int) {
 	// create configuration objects
 	elts := make(map[int]*model.Config, 0)
 	for i := 0; i < n; i++ {
-		elts[i] = &model.Config{
-			ConfigKey: model.ConfigKey{
-				Kind:      MockKind,
-				Name:      fmt.Sprintf("%s%d", MockName, i),
-				Namespace: namespace,
-			},
-			Spec: &MockConfig{
-				Pairs: []*ConfigPair{
-					&ConfigPair{Key: "key", Value: strconv.Itoa(i)},
-				},
-			},
-		}
+		elts[i] = MakeMock(i, namespace)
 	}
 
 	// put all elements


### PR DESCRIPTION
Kubernetes controllers should not rely on strong consistency of the config registry.
Added tests to validate some work flows on using cache + event handling together.