### PR TITLE
Add proxy watcher and auto-configuration for Envoy

### DIFF
--- a/example/echo/Dockerfile-envoy
+++ b/example/echo/Dockerfile-envoy
@@ -1,6 +1,6 @@
 FROM ubuntu:14.04
 ADD envoy_esp /usr/local/bin/envoy
-ADD generic_service_config.json /generic_service_config.json
-ADD server_config.pb.txt /server_config.pb.txt
-ADD envoy.conf /envoy.conf
-CMD /usr/local/bin/envoy -c /envoy.conf -l debug
+ADD generic_service_config.json /etc/envoy/generic_service_config.json
+ADD server_config.pb.txt /etc/envoy/server_config.pb.txt
+ADD cmd /cmd
+CMD /cmd proxy -s manager:8080 --logtostderr -v 2 -n demo

--- a/example/echo/Dockerfile-manager
+++ b/example/echo/Dockerfile-manager
@@ -1,3 +1,3 @@
 FROM ubuntu:14.04
-ADD cmd /manager
-CMD /manager server --logtostderr -v 2
+ADD cmd /cmd
+CMD /cmd server --logtostderr -v 2

--- a/example/echo/build.sh
+++ b/example/echo/build.sh
@@ -1,9 +1,13 @@
 #!/bin/bash
 gcloud config set project istio-test
 
+rm -f cmd
+bazel build //...
+cp ../../bazel-bin/cmd/cmd .
+
 # Expects "mixs", "envoy_esp", "cmd" binaries in the directory
 for s in mixer manager envoy; do
   docker build -t $s -f Dockerfile-$s .
-  docker tag $s gcr.io/istio-test/$s:example
-  gcloud docker -- push gcr.io/istio-test/$s:example
+  docker tag $s gcr.io/istio-test/$s:test
+  gcloud docker -- push gcr.io/istio-test/$s:test
 done

--- a/example/echo/echo.yaml
+++ b/example/echo/echo.yaml
@@ -58,7 +58,7 @@ spec:
     spec:
       containers:
       - name: mixer
-        image: gcr.io/istio-test/mixer:example
+        image: gcr.io/istio-test/mixer:test
         imagePullPolicy: Always
         ports:
         - containerPort: 9091
@@ -89,7 +89,7 @@ spec:
     spec:
       containers:
       - name: envoy
-        image: gcr.io/istio-test/envoy:example
+        image: gcr.io/istio-test/envoy:test
         imagePullPolicy: Always
         ports:
         - containerPort: 80
@@ -120,7 +120,7 @@ spec:
     spec:
       containers:
       - name: manager
-        image: gcr.io/istio-test/manager:example
+        image: gcr.io/istio-test/manager:test
         imagePullPolicy: Always
         ports:
         - containerPort: 8080

--- a/example/echo/server_config.pb.txt
+++ b/example/echo/server_config.pb.txt
@@ -1,3 +1,6 @@
+cloud_tracing_config {
+  force_disable: true
+}
 mixer_options {
-  mixer_server: "mixer.echoheaders"
+  mixer_server: "mixer.demo:grpc"
 }

--- a/model/controller.go
+++ b/model/controller.go
@@ -14,13 +14,21 @@
 
 package model
 
-// Controller defines an event controller loop
+// Controller defines an event controller loop.
+// Used in combination with registry, the controller guarantees the following
+// consistency requirements:
+// - registry view in the controller is as AT LEAST as fresh as the moment
+// notification arrives, but MAY BE more fresh (e.g. "delete" cancels
+// "add" event).
 type Controller interface {
-	// AppendHandler adds a handler for a config resource.
-	// Handler executes on the single worker queue and applies all functions for
-	// a kind to the notification object until all functions stop returning an error.
-	// Note: this method is not thread-safe, please use it before calling Run
-	AppendHandler(kind string, f func(*Config, Event) error) error
+	// AppendHandler appends a handler for a config resource.  Handlers execute
+	// on the single worker queue in the order they are appended.  Handlers
+	// receive the notification event and the associated object.  Note: this
+	// method is not thread-safe, please use it before calling Run
+	AppendHandler(kind string, f func(*Config, Event)) error
+
+	// AppendServiceHandler
+	AppendServiceHandler(f func(*Service, Event)) error
 
 	// Run until a signal is received
 	Run(stop chan struct{})

--- a/platform/kube/minikube_test.go
+++ b/platform/kube/minikube_test.go
@@ -79,7 +79,7 @@ func TestController(t *testing.T) {
 	ctl := NewController(cl, ns, 256*time.Millisecond)
 	added, deleted := 0, 0
 	n := 5
-	ctl.AppendHandler(test.MockKind, func(c *model.Config, ev model.Event) error {
+	ctl.AppendHandler(test.MockKind, func(c *model.Config, ev model.Event) {
 		switch ev {
 		case model.EventAdd:
 			if deleted != 0 {
@@ -93,7 +93,6 @@ func TestController(t *testing.T) {
 			deleted++
 		}
 		glog.Infof("Added %d, deleted %d", added, deleted)
-		return nil
 	})
 	go ctl.Run(stop)
 
@@ -118,7 +117,7 @@ func TestControllerCacheFreshness(t *testing.T) {
 	// validate cache consistency requirement:
 	// When you receive a notification, the cache will be AT LEAST as fresh as
 	// the notification, but it MAY be more fresh.
-	ctl.AppendHandler(test.MockKind, func(c *model.Config, ev model.Event) error {
+	ctl.AppendHandler(test.MockKind, func(c *model.Config, ev model.Event) {
 		elts, _ := ctl.List(test.MockKind, ns)
 		switch ev {
 		case model.EventAdd:
@@ -132,7 +131,6 @@ func TestControllerCacheFreshness(t *testing.T) {
 			}
 			close(stop)
 		}
-		return nil
 	})
 
 	go ctl.Run(stop)

--- a/proxy/envoy/BUILD
+++ b/proxy/envoy/BUILD
@@ -7,6 +7,7 @@ go_library(
         "config.go",
         "discovery.go",
         "resources.go",
+        "watcher.go",
     ],
     visibility = ["//visibility:public"],
     deps = [

--- a/proxy/envoy/agent.go
+++ b/proxy/envoy/agent.go
@@ -72,7 +72,8 @@ func (s *agent) Reload(config *Config) error {
 	}
 
 	// Spin up a new Envoy process.
-	cmd := exec.Command(s.binary, "-c", fname, "--restart-epoch", fmt.Sprint(s.epoch))
+	cmd := exec.Command(s.binary, "-c", fname, "--restart-epoch", fmt.Sprint(s.epoch),
+		"--drain-time-s", "60", "--parent-shutdown-time-s", "90")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Start(); err != nil {

--- a/proxy/envoy/config.go
+++ b/proxy/envoy/config.go
@@ -28,10 +28,8 @@ import (
 	"path/filepath"
 )
 
-const EnvoyConfigPath = "/etc/envoy/"
-
-func (conf *Config) WriteFile() error {
-	file, err := os.Create(EnvoyConfigPath + "envoy.json")
+func (conf *Config) WriteFile(fname string) error {
+	file, err := os.Create(fname)
 	if err != nil {
 		return err
 	}
@@ -181,6 +179,8 @@ func buildRoutes(services []*model.Service) []Route {
 			})
 		}
 	}
+
+	sort.Sort(RoutesByCluster(routes))
 	return routes
 }
 

--- a/proxy/envoy/resources.go
+++ b/proxy/envoy/resources.go
@@ -168,6 +168,21 @@ func (s ClustersByName) Less(i, j int) bool {
 	return s[i].Name < s[j].Name
 }
 
+// RoutesByCluster sorts routes by name
+type RoutesByCluster []Route
+
+func (r RoutesByCluster) Len() int {
+	return len(r)
+}
+
+func (r RoutesByCluster) Swap(i, j int) {
+	r[i], r[j] = r[j], r[i]
+}
+
+func (r RoutesByCluster) Less(i, j int) bool {
+	return r[i].Cluster < r[j].Cluster
+}
+
 // SDS is a service discovery service definition
 type SDS struct {
 	Cluster        Cluster `json:"cluster"`

--- a/proxy/envoy/watcher.go
+++ b/proxy/envoy/watcher.go
@@ -1,0 +1,78 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package envoy
+
+import (
+	"bytes"
+	"time"
+
+	"github.com/golang/glog"
+	"istio.io/manager/model"
+)
+
+// Watcher observes service registry and triggers a reload on a change
+type Watcher interface {
+}
+
+type watcher struct {
+	agent     Agent
+	config    string
+	ds        model.ServiceDiscovery
+	dsAddress string
+}
+
+func NewWatcher(ds model.ServiceDiscovery, ctl model.Controller, dsAddress string, binary string) Watcher {
+	out := &watcher{
+		agent:     NewAgent(binary),
+		ds:        ds,
+		dsAddress: dsAddress,
+	}
+	ctl.AppendServiceHandler(out.notify)
+	return out
+}
+
+func (w *watcher) notify(svc *model.Service, ev model.Event) {
+	config, err := Generate(w.ds.Services(), w.dsAddress)
+	if err != nil {
+		glog.Warningf("Failed to generate Envoy configuration: %v", err)
+		return
+	}
+
+	buf := new(bytes.Buffer)
+	err = config.Write(buf)
+	if err != nil {
+		glog.Warningf("Failed to serialize Envoy configuration: %v", err)
+		return
+	}
+
+	data := buf.String()
+	if data == w.config {
+		glog.V(2).Info("Configuration is identical, skipping reload")
+		return
+	}
+
+	glog.V(2).Infof("Config length %d bytes, old config length %d bytes", len(data), len(w.config))
+	glog.V(10).Infof("Envoy config: %s", data)
+
+	if err := w.agent.Reload(config); err != nil {
+		glog.Warningf("Envoy reload error: %v", err)
+		return
+	}
+
+	w.config = data
+
+	// add a short delay to de-risk race conditions in envoy hot reload code
+	time.Sleep(256 * time.Millisecond)
+}


### PR DESCRIPTION
Complete the proxy supervising process basic implementation.
In this configuration, proxy container has a watcher process that watches for changes to CDS and triggers a hot-reload in Envoy. The watcher creates an Envoy config file from CDS service definitions and inserts a reference to another manager instance acting as SDS.

Eventually, once CDS API is available, we do not need the hot reload. Hot reload would still be necessary for RDS or anything else that's not captured by Envoy runtime APIs.