### PR TITLE
Define service tags

### DIFF
--- a/model/service.go
+++ b/model/service.go
@@ -180,7 +180,11 @@ func ParseServiceString(s string) *Service {
 func (t Tag) String() string {
 	labels := make([]string, 0)
 	for k, v := range t {
-		labels = append(labels, fmt.Sprintf("%s=%s", k, v))
+		if len(v) > 0 {
+			labels = append(labels, fmt.Sprintf("%s=%s", k, v))
+		} else {
+			labels = append(labels, k)
+		}
 	}
 	sort.Strings(labels)
 

--- a/model/service.go
+++ b/model/service.go
@@ -16,18 +16,19 @@ package model
 
 import (
 	"bytes"
+	"fmt"
 	"sort"
 	"strings"
 )
 
 // ServiceDiscovery enumerates Istio service instances
 type ServiceDiscovery interface {
-	// Services list all services and their tags
+	// Services list declarations of all services and their tags
 	Services() []*Service
 	// Endpoints retrieves service instances for a service.
 	// The query takes a union across a set of tags and a set of named ports
 	// defined in the service parameter.
-	// Empty tag set or port set implies the union of all available tags and
+	// Empty tag set or a port set implies the union of all available tags and
 	// ports, respectively.
 	Endpoints(s *Service) []*ServiceInstance
 }
@@ -38,13 +39,16 @@ type Service struct {
 	Name string `json:"name"`
 	// Namespace of the service name, optional
 	Namespace string `json:"namespace,omitempty"`
-	// Tags is a set of declared tags for the service.
-	// An empty set is allowed but tag values must be non-empty strings.
-	Tags []string `json:"tags,omitempty"`
-	// Ports is a set of declared network ports for the service.
-	// Port value is the service port.
-	Ports []Port `json:"ports"`
+	// Tags is a set of declared distinct tags for the service
+	Tags []Tag `json:"tags,omitempty"`
+	// Ports is a set of declared network service ports
+	Ports []Port `json:"ports,omitempty"`
 }
+
+// Tag describes an Istio service tag which provides finer-grained control
+// over the set of service endpoints.
+// Tag is a non-empty set of key-value pairs.
+type Tag map[string]string
 
 // Endpoint defines a network endpoint
 type Endpoint struct {
@@ -52,6 +56,13 @@ type Endpoint struct {
 	Address string `json:"ip_address,omitempty"`
 	// Port on the host address
 	Port Port `json:"port"`
+}
+
+// ServiceInstance binds an endpoint to a service and a tag.
+type ServiceInstance struct {
+	Endpoint Endpoint `json:"endpoint,omitempty"`
+	Service  *Service `json:"service,omitempty"`
+	Tag      *Tag     `json:"tag,omitempty"`
 }
 
 // Port represents a network port
@@ -75,17 +86,8 @@ const (
 	ProtocolUDP   Protocol = "UDP"
 )
 
-// ServiceInstance binds an endpoint to a service and a tag.
-// If the service has no tags, the tag value is an empty string;
-// otherwise, the tag value is an element in the set of service tags.
-type ServiceInstance struct {
-	Endpoint Endpoint `json:"endpoint,omitempty"`
-	Service  *Service `json:"service,omitempty"`
-	Tag      string   `json:"tag,omitempty"`
-}
-
 func (s *Service) String() string {
-	// example: name.namespace:http:my-v1,prod
+	// example: name.namespace:http:env=prod;env=test,version=my-v1
 	var buffer bytes.Buffer
 	buffer.WriteString(s.Name)
 	if len(s.Namespace) > 0 {
@@ -121,11 +123,13 @@ func (s *Service) String() string {
 	if nt > 0 {
 		buffer.WriteString(":")
 		tags := make([]string, nt)
-		copy(tags, s.Tags)
+		for i := 0; i < nt; i++ {
+			tags[i] = s.Tags[i].String()
+		}
 		sort.Strings(tags)
 		for i := 0; i < nt; i++ {
 			if i > 0 {
-				buffer.WriteString(",")
+				buffer.WriteString(";")
 			}
 			buffer.WriteString(tags[i])
 		}
@@ -152,14 +156,17 @@ func ParseServiceString(s string) *Service {
 	} else {
 		names = []string{""}
 	}
-	ports := make([]Port, 0)
+
+	var ports []Port
 	for _, name := range names {
 		ports = append(ports, Port{Name: name})
 	}
 
-	var tags []string
+	var tags []Tag
 	if len(parts) > 2 && len(parts[2]) > 0 {
-		tags = strings.Split(parts[2], ",")
+		for _, tag := range strings.Split(parts[2], ";") {
+			tags = append(tags, ParseTagString(tag))
+		}
 	}
 
 	return &Service{
@@ -168,4 +175,37 @@ func ParseServiceString(s string) *Service {
 		Ports:     ports,
 		Tags:      tags,
 	}
+}
+
+func (t Tag) String() string {
+	labels := make([]string, 0)
+	for k, v := range t {
+		labels = append(labels, fmt.Sprintf("%s=%s", k, v))
+	}
+	sort.Strings(labels)
+
+	var buffer bytes.Buffer
+	var first = true
+	for _, label := range labels {
+		if !first {
+			buffer.WriteString(",")
+		} else {
+			first = false
+		}
+		buffer.WriteString(label)
+	}
+	return buffer.String()
+}
+
+func ParseTagString(s string) Tag {
+	tag := make(map[string]string)
+	for _, pair := range strings.Split(s, ",") {
+		kv := strings.Split(pair, "=")
+		if len(kv) > 1 {
+			tag[kv[0]] = kv[1]
+		} else {
+			tag[kv[0]] = ""
+		}
+	}
+	return tag
 }

--- a/model/service_test.go
+++ b/model/service_test.go
@@ -17,15 +17,25 @@ package model
 import "testing"
 
 var validServices = map[string]Service{
-	"example-service1.default:grpc,http:v1,v2,v3": Service{
+	"example-service1.default:grpc,http:a=b,c=d;e=f": Service{
 		Name:      "example-service1",
 		Namespace: "default",
-		Tags:      []string{"v2", "v3", "v1"},
+		Tags:      []Tag{{"e": "f"}, {"c": "d", "a": "b"}},
 		Ports:     []Port{Port{Name: "http"}, Port{Name: "grpc"}}},
-	"my-service":    Service{Name: "my-service", Ports: []Port{Port{Name: ""}}},
-	"svc.ns":        Service{Name: "svc", Ports: []Port{Port{Name: ""}}, Namespace: "ns"},
-	"svc::v1-test":  Service{Name: "svc", Ports: []Port{Port{Name: ""}}, Tags: []string{"v1-test"}},
-	"svc:http-test": Service{Name: "svc", Ports: []Port{Port{Name: "http-test"}}},
+	"my-service": Service{
+		Name:  "my-service",
+		Ports: []Port{Port{Name: ""}}},
+	"svc.ns": Service{
+		Name:      "svc",
+		Namespace: "ns",
+		Ports:     []Port{Port{Name: ""}}},
+	"svc::istio.io/my_tag-v1.test=my_value-v2.value": Service{
+		Name:  "svc",
+		Tags:  []Tag{{"istio.io/my_tag-v1.test": "my_value-v2.value"}},
+		Ports: []Port{Port{Name: ""}}},
+	"svc:http-test": Service{
+		Name:  "svc",
+		Ports: []Port{Port{Name: "http-test"}}},
 }
 
 func TestServiceString(t *testing.T) {
@@ -44,7 +54,7 @@ func TestServiceString(t *testing.T) {
 		if svc1.Namespace != svc.Namespace {
 			t.Errorf("svc.Name => Got %s, expected %s for %s", svc1.Namespace, svc.Namespace, s)
 		}
-		if !compare(svc1.Tags, svc.Tags) {
+		if !compareTags(svc1.Tags, svc.Tags) {
 			t.Errorf("svc.Tags => Got %#v, expected %#v for %s", svc1.Tags, svc.Tags, s)
 		}
 		if len(svc1.Ports) != len(svc.Ports) {
@@ -53,6 +63,7 @@ func TestServiceString(t *testing.T) {
 	}
 }
 
+// compare two slices of strings as sets
 func compare(a, b []string) bool {
 	ma := make(map[string]bool)
 	mb := make(map[string]bool)
@@ -74,4 +85,16 @@ func compare(a, b []string) bool {
 	}
 
 	return true
+}
+
+// compareTags compares sets of tags
+func compareTags(a, b []Tag) bool {
+	var as, bs []string
+	for _, i := range a {
+		as = append(as, i.String())
+	}
+	for _, j := range b {
+		bs = append(bs, j.String())
+	}
+	return compare(as, bs)
 }

--- a/model/service_test.go
+++ b/model/service_test.go
@@ -33,6 +33,10 @@ var validServices = map[string]Service{
 		Name:  "svc",
 		Tags:  []Tag{{"istio.io/my_tag-v1.test": "my_value-v2.value"}},
 		Ports: []Port{Port{Name: ""}}},
+	"svc:test:prod": Service{
+		Name:  "svc",
+		Tags:  []Tag{{"prod": ""}},
+		Ports: []Port{Port{Name: "test"}}},
 	"svc:http-test": Service{
 		Name:  "svc",
 		Ports: []Port{Port{Name: "http-test"}}},


### PR DESCRIPTION
This PR defines service tag as a label selector (`map[string]string`).
The code to compute endpoints for a service tag will be in a follow-up PR.