### PR TITLE
Add a dummy kubectl config file for testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 /bazel-*
 contrib/cfgeditor/content.go
-platform/kube/config

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,6 @@ before_install:
   - cat .bazelrc.travis .bazelrc.orig > .bazelrc
 
 script:
-  - touch platform/kube/config
   - bazel --output_base=${HOME}/bazel/outbase build //...
   - bazel --output_base=${HOME}/bazel/outbase test //...
 

--- a/platform/kube/config
+++ b/platform/kube/config
@@ -1,0 +1,1 @@
+# A dummy kubectl configuration file used for testing


### PR DESCRIPTION
Currently platform/kube:go_default_test depends on a local config file,
but the file is gitignored. Thus we need to explicitly create that file
before doing `bazel build`. This commit fixes the issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/istio/manager/44)
<!-- Reviewable:end -->
