### PR TITLE
Propagate proxy config to generator

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -90,7 +90,7 @@ Istio Manager provides management plane functionality to the Istio proxy mesh an
 		Short: "Start Istio Proxy sidecar agent",
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			controller := kube.NewController(flags.client, flags.namespace, resyncPeriod)
-			_, err = envoy.NewWatcher(controller, controller, &flags.proxy)
+			_, err = envoy.NewWatcher(controller, controller, controller, &flags.proxy)
 			if err != nil {
 				return
 			}

--- a/proxy/envoy/BUILD
+++ b/proxy/envoy/BUILD
@@ -12,8 +12,10 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//model:go_default_library",
+        "//model/proxy/alphav1/config:go_default_library",
         "@com_github_emicklei_go_restful//:go_default_library",
         "@com_github_golang_glog//:go_default_library",
+        "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_hashicorp_go_multierror//:go_default_library",
     ],
 )

--- a/proxy/envoy/config.go
+++ b/proxy/envoy/config.go
@@ -26,6 +26,7 @@ import (
 	multierror "github.com/hashicorp/go-multierror"
 
 	"fmt"
+	"istio.io/manager/model/proxy/alphav1/config"
 )
 
 // WriteFile saves config to a file
@@ -69,7 +70,9 @@ const (
 )
 
 // Generate Envoy configuration for service instances co-located with Envoy and all services in the mesh
-func Generate(instances []*model.ServiceInstance, services []*model.Service, mesh *MeshConfig) (*Config, error) {
+func Generate(instances []*model.ServiceInstance, services []*model.Service, rules []*config.RouteRule,
+	upstreams []*config.UpstreamCluster, mesh *MeshConfig) (*Config, error) {
+
 	listeners, clusters := buildListeners(instances, services, mesh)
 	// TODO: add catch-all filters to prevent Envoy from crashing
 	listeners = append(listeners, Listener{

--- a/proxy/envoy/watcher.go
+++ b/proxy/envoy/watcher.go
@@ -62,6 +62,7 @@ func NewWatcher(discovery model.ServiceDiscovery, ctl model.Controller, registry
 	}
 
 	handler := func(model.Key, proto.Message, model.Event) { out.reload() }
+
 	if err = ctl.AppendConfigHandler(model.RouteRule, handler); err != nil {
 		return nil, err
 	}

--- a/proxy/envoy/watcher.go
+++ b/proxy/envoy/watcher.go
@@ -75,8 +75,9 @@ func NewWatcher(discovery model.ServiceDiscovery, ctl model.Controller, registry
 }
 
 func (w *watcher) reload() {
+	// FIXME: namespace?
 	config, err := Generate(w.discovery.HostInstances(w.addrs), w.discovery.Services(),
-		w.registry.RouteRules(), w.registry.UpstreamClusters(), w.mesh)
+		w.registry.RouteRules(""), w.registry.UpstreamClusters(""), w.mesh)
 
 	if err != nil {
 		glog.Warningf("Failed to generate Envoy configuration: %v", err)


### PR DESCRIPTION
Modifies the watcher to update the Envoy config on changes to the proxy config definition.