### PR TITLE
Introduce a CLI for configuration registry

### DIFF
--- a/cmd/manager/BUILD
+++ b/cmd/manager/BUILD
@@ -11,11 +11,11 @@ go_library(
         "//model:go_default_library",
         "//platform/kube:go_default_library",
         "//proxy/envoy:go_default_library",
+        "@com_github_ghodss_yaml//:go_default_library",
         "@com_github_golang_glog//:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_hashicorp_go_multierror//:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",
-        "@in_gopkg_yaml_v2//:go_default_library",
         "@io_k8s_client_go//pkg/api:go_default_library",
     ],
 )

--- a/cmd/manager/BUILD
+++ b/cmd/manager/BUILD
@@ -2,15 +2,21 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 go_library(
     name = "go_default_library",
-    srcs = ["main.go"],
+    srcs = [
+        "config.go",
+        "main.go",
+    ],
     visibility = ["//visibility:private"],
     deps = [
         "//model:go_default_library",
         "//platform/kube:go_default_library",
         "//proxy/envoy:go_default_library",
         "@com_github_golang_glog//:go_default_library",
+        "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_hashicorp_go_multierror//:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",
+        "@in_gopkg_yaml_v2//:go_default_library",
+        "@io_k8s_client_go//pkg/api:go_default_library",
     ],
 )
 

--- a/cmd/manager/config.go
+++ b/cmd/manager/config.go
@@ -101,10 +101,11 @@ var (
 				Name:      args[1],
 				Namespace: flags.namespace,
 			})
-			if exists {
-				print(args[0], item)
+			if !exists {
+				return fmt.Errorf("Does not exist")
 			}
-			return fmt.Errorf("Does not exist")
+			print(args[0], item)
+			return nil
 		},
 	}
 

--- a/cmd/manager/config.go
+++ b/cmd/manager/config.go
@@ -1,0 +1,132 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"sort"
+
+	yaml "gopkg.in/yaml.v2"
+
+	"k8s.io/client-go/pkg/api"
+
+	"github.com/spf13/cobra"
+
+	"istio.io/manager/model"
+)
+
+var (
+	kind string
+
+	configCmd = &cobra.Command{
+		Use:   "config",
+		Short: "Istio configuration registry",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			kinds := make([]string, 0)
+			for kind := range model.IstioConfig {
+				kinds = append(kinds, kind)
+			}
+			sort.Strings(kinds)
+			fmt.Printf("Available configuration resources: %v\n", kinds)
+			return nil
+		},
+	}
+
+	putCmd = &cobra.Command{
+		Use:   "put [kind] [name]",
+		Short: "Store a configuration object from standard input YAML",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 2 {
+				return fmt.Errorf("Provide kind and name")
+			}
+			kind, ok := model.IstioConfig[args[0]]
+			if !ok {
+				return fmt.Errorf("Missing kind %s", args[0])
+			}
+			if flags.namespace == "" {
+				flags.namespace = api.NamespaceDefault
+			}
+
+			// read stdin
+			bytes, err := ioutil.ReadAll(os.Stdin)
+			if err != nil {
+				return fmt.Errorf("Cannot read input: %v", err)
+			}
+
+			out := make(map[string]interface{})
+			err = yaml.Unmarshal(bytes, &out)
+			if err != nil {
+				return fmt.Errorf("Cannot read YAML input: %v", err)
+			}
+
+			v, err := kind.FromJSONMap(out)
+			if err != nil {
+				return fmt.Errorf("Cannot parse proto message: %v", err)
+			}
+
+			err = flags.client.Put(model.Key{
+				Kind:      args[0],
+				Name:      args[1],
+				Namespace: flags.namespace,
+			}, v)
+
+			return err
+		},
+	}
+
+	getCmd = &cobra.Command{
+		Use:   "get [kind] [name]",
+		Short: "Retrieve a configuration object",
+	}
+
+	listCmd = &cobra.Command{
+		Use:   "list [kind]",
+		Short: "List configuration objects",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			for _, kind := range args {
+				list, err := flags.client.List(kind, flags.namespace)
+				if err != nil {
+					fmt.Printf("Error listing %s: %v\n", kind, err)
+				} else {
+					for name, item := range list {
+						fmt.Printf("Name %s\n", name)
+						fmt.Println("======")
+						data, err := yaml.Marshal(item)
+						if err != nil {
+							fmt.Printf("Error %v\n", err)
+						} else {
+							fmt.Println(string(data))
+						}
+					}
+				}
+			}
+			return nil
+		},
+	}
+
+	deleteCmd = &cobra.Command{
+		Use:   "delete [kind] [name]",
+		Short: "Delete a configuration object",
+	}
+)
+
+func init() {
+	configCmd.AddCommand(putCmd)
+	configCmd.AddCommand(getCmd)
+	configCmd.AddCommand(listCmd)
+	configCmd.AddCommand(deleteCmd)
+}

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -34,7 +34,7 @@ import (
 type args struct {
 	kubeconfig string
 	namespace  string
-	controller *kube.Controller
+	client     *kube.Client
 	server     serverArgs
 	proxy      envoy.MeshConfig
 }
@@ -55,46 +55,46 @@ var (
 		Short: "Istio Manager",
 		Long: `
 Istio Manager provides management plane functionality to the Istio proxy mesh and Istio Mixer.`,
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) (err error) {
 			glog.V(2).Infof("flags: %#v", flags)
-
-			client, err := kube.NewClient(flags.kubeconfig, model.IstioConfig)
+			flags.client, err = kube.NewClient(flags.kubeconfig, model.IstioConfig)
 			if err != nil {
 				return multierror.Prefix(err, "Failed to connect to Kubernetes API.")
 			}
-			if err = client.RegisterResources(); err != nil {
+			if err = flags.client.RegisterResources(); err != nil {
 				return multierror.Prefix(err, "Failed to register Third-Party Resources.")
 			}
-
-			flags.controller = kube.NewController(client, flags.namespace, resyncPeriod)
-			return nil
+			return
 		},
 	}
 
 	serverCmd = &cobra.Command{
 		Use:   "server",
 		Short: "Start Istio Manager service",
-		Run: func(cmd *cobra.Command, args []string) {
-			sds := envoy.NewDiscoveryService(flags.controller, flags.server.sdsPort)
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			controller := kube.NewController(flags.client, flags.namespace, resyncPeriod)
+			sds := envoy.NewDiscoveryService(controller, flags.server.sdsPort)
 			stop := make(chan struct{})
-			go flags.controller.Run(stop)
+			go controller.Run(stop)
 			go sds.Run()
 			waitSignal(stop)
+			return
 		},
 	}
 
 	proxyCmd = &cobra.Command{
 		Use:   "proxy",
 		Short: "Start Istio Proxy sidecar agent",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			_, err := envoy.NewWatcher(flags.controller, flags.controller, &flags.proxy)
+		RunE: func(cmd *cobra.Command, args []string) (err error) {
+			controller := kube.NewController(flags.client, flags.namespace, resyncPeriod)
+			_, err = envoy.NewWatcher(controller, controller, &flags.proxy)
 			if err != nil {
-				return err
+				return
 			}
 			stop := make(chan struct{})
-			go flags.controller.Run(stop)
+			go controller.Run(stop)
 			waitSignal(stop)
-			return nil
+			return
 		},
 	}
 
@@ -114,7 +114,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&flags.kubeconfig, "kubeconfig", "c", "",
 		"Use a Kubernetes configuration file instead of in-cluster configuration")
 	rootCmd.PersistentFlags().StringVarP(&flags.namespace, "namespace", "n", "",
-		"Monitor the specified namespace instead of all namespaces")
+		"Select the specified namespace instead of all namespaces")
 	rootCmd.PersistentFlags().AddGoFlagSet(flag.CommandLine)
 
 	serverCmd.PersistentFlags().IntVarP(&flags.server.sdsPort, "port", "p", 8080,
@@ -135,6 +135,8 @@ func init() {
 		"Mixer DNS address (or empty to disable Mixer)")
 	rootCmd.AddCommand(proxyCmd)
 	proxyCmd.AddCommand(egressCmd)
+
+	rootCmd.AddCommand(configCmd)
 }
 
 func main() {

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -59,7 +59,10 @@ Istio Manager provides management plane functionality to the Istio proxy mesh an
 			glog.V(2).Infof("flags: %#v", flags)
 			flags.client, err = kube.NewClient(flags.kubeconfig, model.IstioConfig)
 			if err != nil {
-				return multierror.Prefix(err, "Failed to connect to Kubernetes API.")
+				flags.client, err = kube.NewClient(os.Getenv("HOME")+"/.kube/config", model.IstioConfig)
+				if err != nil {
+					return multierror.Prefix(err, "Failed to connect to Kubernetes API.")
+				}
 			}
 			if err = flags.client.RegisterResources(); err != nil {
 				return multierror.Prefix(err, "Failed to register Third-Party Resources.")

--- a/model/BUILD
+++ b/model/BUILD
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "controller.go",
+        "conversion.go",
         "registry.go",
         "service.go",
         "validation.go",

--- a/model/BUILD
+++ b/model/BUILD
@@ -12,6 +12,7 @@ go_library(
     deps = [
         "//model/proxy/alphav1/config:go_default_library",
         "@com_github_golang_glog//:go_default_library",
+        "@com_github_golang_protobuf//jsonpb:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_hashicorp_go_multierror//:go_default_library",
     ],

--- a/model/conversion.go
+++ b/model/conversion.go
@@ -1,0 +1,75 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"encoding/json"
+	"reflect"
+
+	"github.com/golang/protobuf/jsonpb"
+	"github.com/golang/protobuf/proto"
+)
+
+// ToJSON marshals a proto to canonical JSON
+func (ps *ProtoSchema) ToJSON(msg proto.Message) (string, error) {
+	// Marshal from proto to json bytes
+	m := jsonpb.Marshaler{}
+	out, err := m.MarshalToString(msg)
+	if err != nil {
+		return "", err
+	}
+	return out, nil
+}
+
+// ToJSONMap converts a proto message to a generic map using canonical JSON encoding
+// JSON encoding is specified here: https://developers.google.com/protocol-buffers/docs/proto3#json
+func (ps *ProtoSchema) ToJSONMap(msg proto.Message) (map[string]interface{}, error) {
+	js, err := ps.ToJSON(msg)
+	if err != nil {
+		return nil, err
+	}
+
+	// Unmarshal from json bytes to go map
+	var data map[string]interface{}
+	err = json.Unmarshal([]byte(js), &data)
+	if err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}
+
+// FromJSON converts a canonical JSON to a proto message
+func (ps *ProtoSchema) FromJSON(js string) (proto.Message, error) {
+	// Unmarshal from bytes to proto
+	pbt := proto.MessageType(ps.MessageName)
+	pb := reflect.New(pbt.Elem()).Interface().(proto.Message)
+	err := jsonpb.UnmarshalString(js, pb)
+	if err != nil {
+		return nil, err
+	}
+	return pb, nil
+}
+
+// FromJSONMap converts from a generic map to a proto message using canonical JSON encoding
+// JSON encoding is specified here: https://developers.google.com/protocol-buffers/docs/proto3#json
+func (ps *ProtoSchema) FromJSONMap(data map[string]interface{}) (proto.Message, error) {
+	// Marshal to json bytes
+	str, err := json.Marshal(data)
+	if err != nil {
+		return nil, err
+	}
+	return ps.FromJSON(string(str))
+}

--- a/model/registry.go
+++ b/model/registry.go
@@ -15,11 +15,7 @@
 package model
 
 import (
-	"encoding/json"
-	"reflect"
-
 	"github.com/golang/glog"
-	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/proto"
 
 	proxyconfig "istio.io/manager/model/proxy/alphav1/config"
@@ -68,44 +64,6 @@ type ProtoSchema struct {
 	MessageName string
 	// Validate configuration as a protobuf message
 	Validate func(o proto.Message) error
-}
-
-// ToJSONMap converts a proto message to a generic map
-func (ps *ProtoSchema) ToJSONMap(msg proto.Message) (map[string]interface{}, error) {
-	// Marshal from proto to json bytes
-	m := jsonpb.Marshaler{}
-	bytes, err := m.MarshalToString(msg)
-	if err != nil {
-		return nil, err
-	}
-
-	// Unmarshal from json bytes to go map
-	var data map[string]interface{}
-	err = json.Unmarshal([]byte(bytes), &data)
-	if err != nil {
-		return nil, err
-	}
-
-	return data, nil
-}
-
-// FromJSONMap converts from a generic map to a proto message
-func (ps *ProtoSchema) FromJSONMap(data map[string]interface{}) (proto.Message, error) {
-	// Marshal to json bytes
-	str, err := json.Marshal(data)
-	if err != nil {
-		return nil, err
-	}
-
-	// Unmarshal from bytes to proto
-	pbt := proto.MessageType(ps.MessageName)
-	pb := reflect.New(pbt.Elem()).Interface().(proto.Message)
-	err = jsonpb.UnmarshalString(string(str), pb)
-	if err != nil {
-		return nil, err
-	}
-
-	return pb, nil
 }
 
 const (

--- a/platform/kube/BUILD
+++ b/platform/kube/BUILD
@@ -13,7 +13,6 @@ go_library(
     deps = [
         "//model:go_default_library",
         "@com_github_golang_glog//:go_default_library",
-        "@com_github_golang_protobuf//jsonpb:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_hashicorp_go_multierror//:go_default_library",
         "@io_k8s_client_go//kubernetes:go_default_library",


### PR DESCRIPTION
Example:  
```
> cat example
dst_service_name: test
> cat example | bazel-bin/cmd/manager/manager config put route-rule  test  -c ~/.kube/config 
> manager config list route-rule -c ~/.kube/config 
Kind route-rule, Name: test, Namespace: default
======
dstservicename: test
routerule: null


```