### PR TITLE
Update to rules_go latest commit

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,6 +1,6 @@
 git_repository(
     name = "io_bazel_rules_go",
-    commit = "fee2a86ddfcbfbc131bcc1a113ca35ddc46fac96",
+    commit = "76c63b5cd0d47c1f2b47ab4953db96c574af1c1d",
     remote = "https://github.com/bazelbuild/rules_go.git",
 )
 


### PR DESCRIPTION
Bazel 0.4.4 breaks the build with an error like this:

ERROR: .../external/io_bazel_rules_go/go/toolchain/BUILD:20:1: no such package '@io_bazel_rules_go_toolchain//': Not a file: ...external/golang_linux_amd64/BUILD and referenced by '@io_bazel_rules_go//go/toolchain:go_root'.

This commit rolls back the rules to 0.4.3, similar to what has been done for the mixer.