### PR TITLE
Update Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@ node {
   bazel.setVars()
 }
 
-node('master') {
+mainFlow(utils) {
   if (utils.runStage('PRESUBMIT')) {
     def success = true
     utils.updatePullRequest('run')


### PR DESCRIPTION
In the pipeline library I updated the go binary to add a comment to a PR when Jenkins is running. This will be used by Manager in the future. Unfortunately this means that nothing can run on master, since master does not have go installed. The mainFlow() was updated accordingly but Manager Jenkins did not use it. This change fixes that.