### PR TITLE
Implement service node and cluster for envoy

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,7 +49,7 @@ def presubmit(gitUtils, bazel) {
       bazel.test('//...')
     }
     stage('Integration Tests') {
-      sh('bin/e2e.sh -t alpha-' + gitUtils.GIT_SHA + ' -c ""')
+      sh('bin/e2e.sh -t alpha-' + gitUtils.GIT_SHA + ' -d -c ""')
     }
   }
 }

--- a/proxy/envoy/config.go
+++ b/proxy/envoy/config.go
@@ -194,7 +194,7 @@ func buildOutboundFilters(instances []*model.ServiceInstance, services []*model.
 				http := httpConfigs.EnsurePort(port.Port)
 				http.VirtualHosts = append(http.VirtualHosts, host)
 			default:
-				glog.Warningf("Unsupported outbound protocol %v for port %d", port.Protocol, port)
+				glog.Warningf("Unsupported outbound protocol %v for port %d", port.Protocol, port.Port)
 			}
 		}
 	}

--- a/test/integration/driver.go
+++ b/test/integration/driver.go
@@ -73,7 +73,7 @@ func init() {
 		"Docker tag")
 	flag.StringVarP(&namespace, "namespace", "n", "",
 		"Namespace to use for testing (empty to create/delete temporary one)")
-	flag.BoolVarP(&verbose, "verbose", "v", false,
+	flag.BoolVarP(&verbose, "dump", "d", false,
 		"Dump proxy logs and request logs")
 }
 
@@ -109,12 +109,12 @@ func main() {
 		log.Fatal(err)
 	}
 	log.Println("pods:", pods)
-	if verbose {
-		dumpProxyLogs(pods["a"])
-		dumpProxyLogs(pods["b"])
-	}
 
 	if err := checkBasicReachability(pods); err != nil {
+		if verbose {
+			dumpProxyLogs(pods["a"])
+			dumpProxyLogs(pods["b"])
+		}
 		log.Fatal(err)
 	}
 	if err := checkRouting(pods); err != nil {

--- a/test/integration/http-service-versions.yaml.tmpl
+++ b/test/integration/http-service-versions.yaml.tmpl
@@ -55,10 +55,24 @@ spec:
           runAsUser: 1337
         args:
           - proxy
+          - sidecar
           - -s
           - manager:8080
           - --logtostderr
           - -v
           - "2"
         imagePullPolicy: Always
+        env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
 ---

--- a/test/integration/http-service.yaml.tmpl
+++ b/test/integration/http-service.yaml.tmpl
@@ -54,10 +54,24 @@ spec:
           runAsUser: 1337
         args:
           - proxy
+          - sidecar
           - -s
           - manager:8080
           - --logtostderr
           - -v
           - "2"
         imagePullPolicy: Always
+        env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
 ---

--- a/test/integration/manager.yaml.tmpl
+++ b/test/integration/manager.yaml.tmpl
@@ -65,7 +65,7 @@ spec:
       containers:
       - name: manager
         image: {{.hub}}/runtime:{{.tag}}
-        args: ["server", "--logtostderr", "-v", "2"]
+        args: ["discovery", "--logtostderr", "-v", "2"]
         imagePullPolicy: Always
         ports:
         - containerPort: 8080


### PR DESCRIPTION
- uses downward api to propagate pod names
- rename CLI commands: server => discovery, proxy => proxy sidecar
- decrease drain time to 30s
- print test logs in jenkins