### PR TITLE
Rewrite ingress traffic host header to destination service hostname

### DIFF
--- a/proxy/envoy/ingress.go
+++ b/proxy/envoy/ingress.go
@@ -169,8 +169,9 @@ func (w *ingressWatcher) generateConfig() (*Config, error) {
 // buildIngressRoute translates an ingress rule to an Envoy route
 func buildIngressRoute(rule *config.RouteRule) *Route {
 	route := &Route{
-		Path:   "",
-		Prefix: "/",
+		Path:        "",
+		Prefix:      "/",
+		HostRewrite: rule.Destination,
 	}
 
 	if rule.Match != nil {

--- a/proxy/envoy/resources.go
+++ b/proxy/envoy/resources.go
@@ -124,10 +124,13 @@ type Runtime struct {
 
 // Route definition
 type Route struct {
-	Runtime       *Runtime `json:"runtime,omitempty"`
-	Path          string   `json:"path,omitempty"`
-	Prefix        string   `json:"prefix,omitempty"`
-	PrefixRewrite string   `json:"prefix_rewrite,omitempty"`
+	Runtime *Runtime `json:"runtime,omitempty"`
+
+	Path   string `json:"path,omitempty"`
+	Prefix string `json:"prefix,omitempty"`
+
+	PrefixRewrite string `json:"prefix_rewrite,omitempty"`
+	HostRewrite   string `json:"host_rewrite,omitempty"`
 
 	Cluster          string           `json:"cluster"`
 	WeightedClusters *WeightedCluster `json:"weighted_clusters,omitempty"`


### PR DESCRIPTION
A complementary fix to #150/#160, where inbound service proxy expects the host header on incoming requests to match the local pods IP / service hostname.

For the ingress controller case, the host header is either set by the client (to a virtual host name != service host name) and forwarded as-is; or set by the Envoy ingress controller to the local host.

This PR utilizes Envoy's support for host rewrite (see [docs](https://lyft.github.io/envoy/docs/configuration/http_conn_man/route_config/route.html)) to set the host header to the target service host name.

Note: tested locally/manually to verify that I can hit a backend service exposed via an ingress.