### PR TITLE
Set gometalinter to run linters sequentially

### DIFF
--- a/bin/check.sh
+++ b/bin/check.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ex
 
-gometalinter --deadline=300s --disable-all\
+gometalinter --concurrency=1 --deadline=300s --disable-all\
   --enable=aligncheck\
   --enable=deadcode\
   --enable=errcheck\

--- a/bin/check.sh
+++ b/bin/check.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ex
 
-gometalinter --concurrency=1 --deadline=300s --disable-all\
+gometalinter --concurrency=4 --enable-gc --deadline=300s --disable-all\
   --enable=aligncheck\
   --enable=deadcode\
   --enable=errcheck\


### PR DESCRIPTION
This PR sets gometalinter to run a single linter at a time, instead of its default of 16 linters concurrently.

On my dev VM, this has improved its runtime duration to ~2:20 (instead of ~4:00), while greatly reducing its memory usage (no more OOMs, no memory leaks).

As a bonus, it prevents gometalinter from producing lint errors (varcheck/aligncheck) on stdlib code:
```
/usr/local/go/src/os/user/lookup.go:38:9:warning: undeclared name: listGroups (aligncheck)
/usr/local/go/src/os/user/lookup.go:9:9:warning: undeclared name: current (aligncheck)
/usr/local/go/src/os/user/lookup.go:15:9:warning: undeclared name: lookupUser (aligncheck)
/usr/local/go/src/os/user/lookup.go:21:9:warning: undeclared name: lookupUserId (aligncheck)
/usr/local/go/src/os/user/lookup.go:27:9:warning: undeclared name: lookupGroup (aligncheck)
/usr/local/go/src/os/user/lookup.go:33:9:warning: undeclared name: lookupGroupId (aligncheck)
```
