### PR TITLE
Add envoy resource definitions for TCP network filters

### DIFF
--- a/proxy/envoy/config.go
+++ b/proxy/envoy/config.go
@@ -117,11 +117,10 @@ func build(instances []*model.ServiceInstance, services []*model.Service,
 	inbound := buildInboundFilters(instances)
 
 	// merge the two sets of route configs
-	routeConfigs := make(RouteConfigs)
+	routeConfigs := make(HTTPRouteConfigs)
 	for port, routeConfig := range inbound {
 		routeConfigs[port] = routeConfig
 	}
-
 	for port, outgoing := range outbound {
 		if incoming, ok := routeConfigs[port]; ok {
 			// If the traffic is sent to a service that has instances co-located with the proxy,
@@ -142,7 +141,7 @@ func build(instances []*model.ServiceInstance, services []*model.Service,
 
 		filters := buildFaultFilters(config, routeConfig)
 
-		filters = append(filters, Filter{
+		filters = append(filters, HTTPFilter{
 			Type:   "decoder",
 			Name:   "router",
 			Config: FilterRouterConfig{},
@@ -153,7 +152,7 @@ func build(instances []*model.ServiceInstance, services []*model.Service,
 			Filters: []*NetworkFilter{{
 				Type: "read",
 				Name: HTTPConnectionManager,
-				Config: NetworkFilterConfig{
+				Config: HTTPFilterConfig{
 					CodecType:  "auto",
 					StatPrefix: "http",
 					AccessLog: []AccessLog{{
@@ -166,6 +165,7 @@ func build(instances []*model.ServiceInstance, services []*model.Service,
 		}
 		listeners = append(listeners, listener)
 	}
+
 	sort.Sort(ListenersByPort(listeners))
 
 	clusters = clusters.Normalize()
@@ -176,13 +176,18 @@ func build(instances []*model.ServiceInstance, services []*model.Service,
 	return listeners, clusters
 }
 
+// TODO(ayj) - refactor filter builder functions to build both HTTP and TCP
+// filters. Does RouteRule's precedence apply to al protocols such,
+// for example, we need to handle ordering between HTTP and TCP, or should
+// we enforce explicit ordering, e.g. HTTP before TCP?
+
 // buildOutboundFilters creates route configs indexed by ports for the traffic outbound
 // from the proxy instance
 func buildOutboundFilters(instances []*model.ServiceInstance, services []*model.Service,
-	config *model.IstioRegistry, mesh *MeshConfig) RouteConfigs {
+	config *model.IstioRegistry, mesh *MeshConfig) HTTPRouteConfigs {
 	// used for shortcut domain names for outbound hostnames
 	suffix := sharedInstanceHost(instances)
-	httpConfigs := make(RouteConfigs)
+	httpConfigs := make(HTTPRouteConfigs)
 
 	// outbound connections/requests are redirected to service ports; we create a
 	// map for each service port to define filters
@@ -205,10 +210,10 @@ func buildOutboundFilters(instances []*model.ServiceInstance, services []*model.
 
 // buildInboundFilters creates route configs indexed by ports for the traffic inbound
 // to co-located service instances
-func buildInboundFilters(instances []*model.ServiceInstance) RouteConfigs {
+func buildInboundFilters(instances []*model.ServiceInstance) HTTPRouteConfigs {
 	// used for shortcut domain names for hostnames
 	suffix := sharedInstanceHost(instances)
-	httpConfigs := make(RouteConfigs)
+	httpConfigs := make(HTTPRouteConfigs)
 
 	// inbound connections/requests are redirected to the endpoint port but appear to be sent
 	// to the service port
@@ -218,7 +223,7 @@ func buildInboundFilters(instances []*model.ServiceInstance) RouteConfigs {
 		case model.ProtocolHTTP, model.ProtocolHTTP2, model.ProtocolGRPC:
 			cluster := buildInboundCluster(instance.Endpoint.Port, port.Protocol)
 			route := buildDefaultRoute(cluster)
-			host := buildVirtualHost(instance.Service, port, suffix, []*Route{route})
+			host := buildVirtualHost(instance.Service, port, suffix, []*HTTPRoute{route})
 
 			// insert explicit instance ip:port as a hostname field
 			host.Domains = append(host.Domains, fmt.Sprintf("%s:%d", instance.Endpoint.Address, instance.Endpoint.Port))

--- a/proxy/envoy/config.go
+++ b/proxy/envoy/config.go
@@ -176,11 +176,6 @@ func build(instances []*model.ServiceInstance, services []*model.Service,
 	return listeners, clusters
 }
 
-// TODO(ayj) - refactor filter builder functions to build both HTTP and TCP
-// filters. Does RouteRule's precedence apply to al protocols such,
-// for example, we need to handle ordering between HTTP and TCP, or should
-// we enforce explicit ordering, e.g. HTTP before TCP?
-
 // buildOutboundFilters creates route configs indexed by ports for the traffic outbound
 // from the proxy instance
 func buildOutboundFilters(instances []*model.ServiceInstance, services []*model.Service,

--- a/proxy/envoy/config_test.go
+++ b/proxy/envoy/config_test.go
@@ -21,17 +21,17 @@ import (
 
 func TestRoutesByPath(t *testing.T) {
 	cases := []struct {
-		in       []*Route
-		expected []*Route
+		in       []*HTTPRoute
+		expected []*HTTPRoute
 	}{
 
 		// Case 2: Prefix before path
 		{
-			in: []*Route{
+			in: []*HTTPRoute{
 				{Prefix: "/api"},
 				{Path: "/api/v1"},
 			},
-			expected: []*Route{
+			expected: []*HTTPRoute{
 				{Path: "/api/v1"},
 				{Prefix: "/api"},
 			},
@@ -39,11 +39,11 @@ func TestRoutesByPath(t *testing.T) {
 
 		// Case 3: Longer prefix before shorter prefix
 		{
-			in: []*Route{
+			in: []*HTTPRoute{
 				{Prefix: "/api"},
 				{Prefix: "/api/v1"},
 			},
-			expected: []*Route{
+			expected: []*HTTPRoute{
 				{Prefix: "/api/v1"},
 				{Prefix: "/api"},
 			},
@@ -52,7 +52,7 @@ func TestRoutesByPath(t *testing.T) {
 
 	// Function to determine if two *Route slices
 	// are the same (same Routes, same order)
-	sameOrder := func(r1, r2 []*Route) bool {
+	sameOrder := func(r1, r2 []*HTTPRoute) bool {
 		for i, r := range r1 {
 			if r.Path != r2[i].Path || r.Prefix != r2[i].Prefix {
 				return false

--- a/proxy/envoy/ingress.go
+++ b/proxy/envoy/ingress.go
@@ -105,7 +105,7 @@ func (w *ingressWatcher) generateConfig() (*Config, error) {
 	// Phase 2: create a VirtualHost for each host
 	vhosts := make([]*VirtualHost, 0, len(rulesByHost))
 	for host, hostRules := range rulesByHost {
-		routes := make([]*Route, 0, len(hostRules))
+		routes := make([]*HTTPRoute, 0, len(hostRules))
 		for _, rule := range hostRules {
 			routes = append(routes, buildIngressRoute(rule))
 		}
@@ -119,7 +119,7 @@ func (w *ingressWatcher) generateConfig() (*Config, error) {
 	}
 	sort.Sort(HostsByName(vhosts))
 
-	rConfig := &RouteConfig{VirtualHosts: vhosts}
+	rConfig := &HTTPRouteConfig{VirtualHosts: vhosts}
 
 	httpListener := &Listener{
 		Port:       80,
@@ -128,12 +128,12 @@ func (w *ingressWatcher) generateConfig() (*Config, error) {
 			{
 				Type: "read",
 				Name: HTTPConnectionManager,
-				Config: NetworkFilterConfig{
+				Config: HTTPFilterConfig{
 					CodecType:   "auto",
 					StatPrefix:  "http",
 					AccessLog:   []AccessLog{{Path: DefaultAccessLog}},
 					RouteConfig: rConfig,
-					Filters: []Filter{
+					Filters: []HTTPFilter{
 						{
 							Type:   "decoder",
 							Name:   "router",
@@ -167,8 +167,8 @@ func (w *ingressWatcher) generateConfig() (*Config, error) {
 }
 
 // buildIngressRoute translates an ingress rule to an Envoy route
-func buildIngressRoute(rule *config.RouteRule) *Route {
-	route := &Route{
+func buildIngressRoute(rule *config.RouteRule) *HTTPRoute {
+	route := &HTTPRoute{
 		Path:        "",
 		Prefix:      "/",
 		HostRewrite: rule.Destination,

--- a/proxy/envoy/resources.go
+++ b/proxy/envoy/resources.go
@@ -227,9 +227,9 @@ type HTTPFilterConfig struct {
 type TCPRoute struct {
 	Cluster           string   `json:"cluster"`
 	DestinationIPList []string `json:"destination_ip_list,omitempty"`
-	DestinationPorts  []string `json:"destination_ports,omitempty"`
+	DestinationPorts  string   `json:"destination_ports,omitempty"`
 	SourceIPList      []string `json:"source_ip_list,omitempty"`
-	SourcePorts       []string `json:"source_ports,omitempty"`
+	SourcePorts       string   `json:"source_ports,omitempty"`
 }
 
 // TCPRouteConfigs provides routes by port
@@ -267,7 +267,7 @@ type NetworkFilter struct {
 type Listener struct {
 	Port           int              `json:"port"`
 	Filters        []*NetworkFilter `json:"filters"`
-	BindToPort     bool             `json:"bind_to_port,omitempty"`
+	BindToPort     bool             `json:"bind_to_port"`
 	UseOriginalDst bool             `json:"use_original_dst,omitempty"`
 }
 

--- a/proxy/envoy/resources.go
+++ b/proxy/envoy/resources.go
@@ -47,8 +47,10 @@ const (
 	DefaultAccessLog = "/dev/stdout"
 	LbTypeRoundRobin = "round_robin"
 
-	// HTTPConnectionManager is the name of HTTP filter
+	// HTTPConnectionManager is the name of HTTP filter.
 	HTTPConnectionManager = "http_connection_manager"
+	// TCPProxyFilter is the name of the TCP Proxy network filter.
+	TCPProxyFilter = "tcp_proxy"
 
 	// URI HTTP header
 	HeaderURI = "uri"
@@ -109,8 +111,8 @@ type FilterRouterConfig struct {
 	DynamicStats bool `json:"dynamic_stats,omitempty"`
 }
 
-// Filter definition
-type Filter struct {
+// HTTPFilter definition
+type HTTPFilter struct {
 	Type   string      `json:"type"`
 	Name   string      `json:"name"`
 	Config interface{} `json:"config"`
@@ -122,8 +124,8 @@ type Runtime struct {
 	Default int    `json:"default"`
 }
 
-// Route definition
-type Route struct {
+// HTTPRoute definition
+type HTTPRoute struct {
 	Runtime *Runtime `json:"runtime,omitempty"`
 
 	Path   string `json:"path,omitempty"`
@@ -166,20 +168,20 @@ type WeightedClusterEntry struct {
 
 // VirtualHost definition
 type VirtualHost struct {
-	Name    string   `json:"name"`
-	Domains []string `json:"domains"`
-	Routes  []*Route `json:"routes"`
+	Name    string       `json:"name"`
+	Domains []string     `json:"domains"`
+	Routes  []*HTTPRoute `json:"routes"`
 }
 
-// RouteConfig definition
-type RouteConfig struct {
+// HTTPRouteConfig definition
+type HTTPRouteConfig struct {
 	VirtualHosts []*VirtualHost `json:"virtual_hosts"`
 }
 
 // Merge operation selects a union of two route configs prioritizing the first.
 // It matches virtual hosts by name.
-func (rc *RouteConfig) merge(that *RouteConfig) *RouteConfig {
-	out := &RouteConfig{}
+func (rc *HTTPRouteConfig) merge(that *HTTPRouteConfig) *HTTPRouteConfig {
+	out := &HTTPRouteConfig{}
 	set := make(map[string]bool)
 	for _, host := range rc.VirtualHosts {
 		set[host.Name] = true
@@ -194,7 +196,7 @@ func (rc *RouteConfig) merge(that *RouteConfig) *RouteConfig {
 }
 
 // Clusters aggregates clusters across routes
-func (rc *RouteConfig) clusters() []*Cluster {
+func (rc *HTTPRouteConfig) clusters() []*Cluster {
 	out := make([]*Cluster, 0)
 	for _, host := range rc.VirtualHosts {
 		for _, route := range host.Routes {
@@ -211,40 +213,72 @@ type AccessLog struct {
 	Filter string `json:"filter,omitempty"`
 }
 
-// NetworkFilterConfig definition
-type NetworkFilterConfig struct {
-	CodecType         string       `json:"codec_type"`
-	StatPrefix        string       `json:"stat_prefix"`
-	GenerateRequestID bool         `json:"generate_request_id,omitempty"`
-	RouteConfig       *RouteConfig `json:"route_config"`
-	Filters           []Filter     `json:"filters"`
-	AccessLog         []AccessLog  `json:"access_log"`
-	Cluster           string       `json:"cluster,omitempty"`
+// HTTPFilterConfig definition
+type HTTPFilterConfig struct {
+	CodecType         string           `json:"codec_type"`
+	StatPrefix        string           `json:"stat_prefix"`
+	GenerateRequestID bool             `json:"generate_request_id,omitempty"`
+	RouteConfig       *HTTPRouteConfig `json:"route_config"`
+	Filters           []HTTPFilter     `json:"filters"`
+	AccessLog         []AccessLog      `json:"access_log"`
+}
+
+// TCPRoute definition
+type TCPRoute struct {
+	Cluster           string   `json:"cluster"`
+	DestinationIPList []string `json:"destination_ip_list,omitempty"`
+	DestinationPorts  []string `json:"destination_ports,omitempty"`
+	SourceIPList      []string `json:"source_ip_list,omitempty"`
+	SourcePorts       []string `json:"source_ports,omitempty"`
+}
+
+// TCPRouteConfigs provides routes by port
+type TCPRouteConfigs map[int]*TCPRouteConfig
+
+// TCPRouteConfig (or generalize as RouteConfig or L4RouteConfig for TCP/UDP?)
+type TCPRouteConfig struct {
+	Routes []TCPRoute `json:"routes"`
+}
+
+// EnsurePort creates a route config if necessary
+func (hosts TCPRouteConfigs) EnsurePort(port int) *TCPRouteConfig {
+	config, ok := hosts[port]
+	if !ok {
+		config = &TCPRouteConfig{}
+		hosts[port] = config
+	}
+	return config
+}
+
+// TCPProxyFilterConfig definition
+type TCPProxyFilterConfig struct {
+	StatPrefix  string         `json:"stat_prefix"`
+	RouteConfig TCPRouteConfig `json:"route_config"`
 }
 
 // NetworkFilter definition
 type NetworkFilter struct {
-	Type   string              `json:"type"`
-	Name   string              `json:"name"`
-	Config NetworkFilterConfig `json:"config"`
+	Type   string      `json:"type"`
+	Name   string      `json:"name"`
+	Config interface{} `json:"config"`
 }
 
 // Listener definition
 type Listener struct {
 	Port           int              `json:"port"`
 	Filters        []*NetworkFilter `json:"filters"`
-	BindToPort     bool             `json:"bind_to_port"`
+	BindToPort     bool             `json:"bind_to_port,omitempty"`
 	UseOriginalDst bool             `json:"use_original_dst,omitempty"`
 }
 
-// RouteConfigs provides routes by virtual host and port
-type RouteConfigs map[int]*RouteConfig
+// HTTPRouteConfigs provides routes by virtual host and port
+type HTTPRouteConfigs map[int]*HTTPRouteConfig
 
 // EnsurePort creates a route config if necessary
-func (hosts RouteConfigs) EnsurePort(port int) *RouteConfig {
+func (hosts HTTPRouteConfigs) EnsurePort(port int) *HTTPRouteConfig {
 	config, ok := hosts[port]
 	if !ok {
-		config = &RouteConfig{}
+		config = &HTTPRouteConfig{}
 		hosts[port] = config
 	}
 	return config
@@ -364,7 +398,7 @@ func (s HostsByName) Less(i, j int) bool {
 //
 // This order ensures that prefix path routes do not shadow more
 // specific routes which share the same prefix.
-type RoutesByPath []*Route
+type RoutesByPath []*HTTPRoute
 
 func (r RoutesByPath) Len() int {
 	return len(r)

--- a/proxy/envoy/route.go
+++ b/proxy/envoy/route.go
@@ -35,8 +35,8 @@ const (
 	OutboundClusterPrefix = "outbound:"
 )
 
-func buildDefaultRoute(cluster *Cluster) *Route {
-	return &Route{
+func buildDefaultRoute(cluster *Cluster) *HTTPRoute {
+	return &HTTPRoute{
 		Prefix:   "/",
 		Cluster:  cluster.Name,
 		clusters: []*Cluster{cluster},
@@ -77,8 +77,8 @@ func buildOutboundCluster(hostname string, port *model.Port, tags model.Tags) *C
 }
 
 // buildHTTPRoutes assembles all routes for the hostname destination
-func buildHTTPRoutes(hostname string, port *model.Port, config *model.IstioRegistry) []*Route {
-	routes := make([]*Route, 0)
+func buildHTTPRoutes(hostname string, port *model.Port, config *model.IstioRegistry) []*HTTPRoute {
+	routes := make([]*HTTPRoute, 0)
 	for _, rule := range config.DestinationRouteRules(hostname) {
 		// TODO: rule applies always, need to check if it's actually HTTP rule
 		routes = append(routes, buildHTTPRoute(rule, port))
@@ -89,8 +89,8 @@ func buildHTTPRoutes(hostname string, port *model.Port, config *model.IstioRegis
 }
 
 // buildHTTPRoute translates a route rule to an Envoy route
-func buildHTTPRoute(rule *config.RouteRule, port *model.Port) *Route {
-	route := &Route{
+func buildHTTPRoute(rule *config.RouteRule, port *model.Port) *HTTPRoute {
+	route := &HTTPRoute{
 		Path:   "",
 		Prefix: "/",
 	}
@@ -158,7 +158,7 @@ func buildSDSCluster(mesh *MeshConfig) *Cluster {
 // "svc.ns.svc.cluster.local:http".
 // Suffix provides the proxy context information - it is the shared sub-domain between co-located
 // service instances (e.g. "namespace", "svc", "cluster", "local")
-func buildVirtualHost(svc *model.Service, port *model.Port, suffix []string, routes []*Route) *VirtualHost {
+func buildVirtualHost(svc *model.Service, port *model.Port, suffix []string, routes []*HTTPRoute) *VirtualHost {
 	hosts := make([]string, 0)
 	domains := make([]string, 0)
 	parts := strings.Split(svc.Hostname, ".")


### PR DESCRIPTION
This should be a non-functional change that adds TCP network filter definitions. 

Next step is to update the config generation (e.g. buildOutboundFilters) to generate the listener and cluster structs for TCP routes, merge HTTP and TCP listener/clusters based on some order of precedence (e.g. HTTP always higher priority than TCP, use RouteRule precedence), and then update the integration test to test non-HTTP services.