### PR TITLE
Use fully qualified image name (FQIN) for known good mixer image flag

### DIFF
--- a/bin/e2e.sh
+++ b/bin/e2e.sh
@@ -6,14 +6,14 @@ debug_suffix=""
 
 # manager is known to work with this mixer build
 # update manually
-mixerTag="ea3a8d3e2feb9f06256f92cda5194cc1ea6b599e"
+mixerImage="gcr.io/istio-testing/mixer:ea3a8d3e2feb9f06256f92cda5194cc1ea6b599e"
 
 args=""
 while [[ $# -gt 0 ]]; do
     case "$1" in
         -h) hub="$2"; shift ;;
         -t) tag="$2"; shift ;;
-        --mixerTag) mixerTag="$2"; shift ;;
+        --mixerImage) mixerImage="$2"; shift ;;
         --skipBuild) SKIP_BUILD=1 ;;
         -n) namespace="$2"; shift ;;
         --use_debug_image) debug_suffix="_debug" ;;
@@ -44,8 +44,8 @@ fi
 [[ ! -z "$hub" ]]       && args=$args" -h $hub"
 [[ ! -z "$namespace" ]] && args=$args" -n $namespace"
 
-# mixerTag will never be empty
-args=$args" --mixerTag $mixerTag"
+# mixerImage will never be empty
+args=$args" --mixerImage $mixerImage"
 
 
 bazel $BAZEL_ARGS run //test/integration -- $args --norouting

--- a/test/integration/driver.go
+++ b/test/integration/driver.go
@@ -62,7 +62,7 @@ var (
 	inClusterConfig  bool
 	hub              string
 	tag              string
-	mixerTag         string
+	mixerImage       string
 	namespace        string
 	verbose          bool
 	norouting        bool
@@ -92,8 +92,8 @@ func init() {
 	flag.StringVarP(&tag, "tag", "t", "",
 		"Docker tag")
 	// manually update default mixer build tag.
-	flag.StringVarP(&mixerTag, "mixerTag", "", "ea3a8d3e2feb9f06256f92cda5194cc1ea6b599e",
-		"Mixer Docker tag")
+	flag.StringVarP(&mixerImage, "mixerImage", "", "gcr.io/istio-testing/mixer:ea3a8d3e2feb9f06256f92cda5194cc1ea6b599e",
+		"Mixer Docker image")
 	flag.StringVarP(&namespace, "namespace", "n", "",
 		"Namespace to use for testing (empty to create/delete temporary one)")
 	flag.BoolVarP(&verbose, "dump", "d", false,
@@ -116,8 +116,8 @@ func setup() {
 	if tag == "" {
 		log.Fatal("No docker tag specified with -t or --tag")
 	}
-	if mixerTag == "" {
-		log.Fatal("No mixer tag specified with --mixerTag, 'latest?'")
+	if mixerImage == "" {
+		log.Fatal("No mixer tag specified with --mixerImage, 'latest?'")
 	}
 	log.Printf("hub %v, tag %v", hub, tag)
 
@@ -201,15 +201,15 @@ func deploy(name, svcName, dType, namespace, port1, port2, version string) error
 	w = bufio.NewWriter(f)
 
 	if err := write("test/integration/"+dType+".yaml.tmpl", map[string]string{
-		"hub":       hub,
-		"tag":       tag,
-		"mixerTag":  mixerTag,
-		"namespace": namespace,
-		"service":   svcName,
-		"name":      name,
-		"port1":     port1,
-		"port2":     port2,
-		"version":   version,
+		"hub":        hub,
+		"tag":        tag,
+		"mixerImage": mixerImage,
+		"namespace":  namespace,
+		"service":    svcName,
+		"name":       name,
+		"port1":      port1,
+		"port2":      port2,
+		"version":    version,
 	}, w); err != nil {
 		return err
 	}

--- a/test/integration/driver.go
+++ b/test/integration/driver.go
@@ -117,7 +117,7 @@ func setup() {
 		log.Fatal("No docker tag specified with -t or --tag")
 	}
 	if mixerImage == "" {
-		log.Fatal("No mixer tag specified with --mixerImage, 'latest?'")
+		log.Fatal("No mixer image specified with --mixerImage, 'latest?'")
 	}
 	log.Printf("hub %v, tag %v", hub, tag)
 

--- a/test/integration/mixer.yaml.tmpl
+++ b/test/integration/mixer.yaml.tmpl
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
       - name: mixer
-        image: {{.hub}}/mixer:{{.mixerTag}}
+        image: {{.mixerImage}}
         imagePullPolicy: Always
         ports:
         - containerPort: 9091


### PR DESCRIPTION
The current bin/e2e.sh script assumes the known good prebuilt mixer image is stored in the same hub as the manager images, i.e. gcr.io/istio-testing. This doesn't work if user specifies alternate docker hubs, e.g. docker.io. 