### PR TITLE
Publish manager docker images via Jenkin's post submit hook

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,6 +29,13 @@ mainFlow(utils) {
       utils.updatePullRequest('verify', success)
     }
   }
+  if (utils.runStage('POSTSUBMIT')) {
+    buildNode(gitUtils) {
+      bazel.updateBazelRc()
+      // TODO(sebastienvas) add necessary docker hub credentials here
+      sh 'docker/release-docker --hub docker.io/istio --tags ' gitUtils.GIT_SHA ',$(date +%Y%m%d%H%M%S)' 
+    }
+  }
 }
 
 def presubmit(gitUtils, bazel) {

--- a/bin/release-docker.sh
+++ b/bin/release-docker.sh
@@ -35,7 +35,7 @@ set -ex
 for image in $images; do
     bazel $BAZEL_ARGS run //docker:$image
     for tag in $tags; do
-        docker tag istio/docker:init $hub/$image:$tag
+        docker tag istio/docker:$image $hub/$image:$tag
         docker push $hub/$image:$tag
     done
 done

--- a/bin/release-docker.sh
+++ b/bin/release-docker.sh
@@ -36,5 +36,8 @@ for image in $images; do
     for tag in $tags; do
         bazel $BAZEL_ARGS run //docker:$image $hub/$image:$tag
         docker push $hub/$image:$tag
+
+        docker tag $hub/$image:$tag $hub/$image:latest
+        docker push $hub/$image:latest
     done
 done

--- a/bin/release-docker.sh
+++ b/bin/release-docker.sh
@@ -2,7 +2,7 @@
 
 # Example usage:
 #
-# docker/release-docker --hub docker.io/istio --tags $(git rev-parse --short HEAD),$(date +%Y%m%d%H%M%S)"
+# docker/release-docker --hub docker.io/istio --tags $(git rev-parse --short # HEAD),$(date +%Y%m%d%H%M%S),latest"
 
 function usage() {
     echo "$0 --hub <docker image repository> --tags <comma seperated list of docker image tags>"
@@ -33,11 +33,9 @@ fi
 set -ex
 
 for image in $images; do
+    bazel $BAZEL_ARGS run //docker:$image
     for tag in $tags; do
-        bazel $BAZEL_ARGS run //docker:$image $hub/$image:$tag
+        docker tag istio/docker:init $hub/$image:$tag
         docker push $hub/$image:$tag
-
-        docker tag $hub/$image:$tag $hub/$image:latest
-        docker push $hub/$image:latest
     done
 done

--- a/docker/release-docker
+++ b/docker/release-docker
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+# Example usage:
+#
+# docker/release-docker --hub docker.io/istio --tags $(git rev-parse --short HEAD),$(date +%Y%m%d%H%M%S)"
+
+function usage() {
+    echo "$0 --hub <docker image repository> --tags <comma seperated list of docker image tags>"
+    exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --hub) hub="$2"; shift ;;
+        --tags) tags="$2"; shift ;;
+        *) usage ;;
+    esac
+    shift
+done
+
+[[ -z $hub ]] && usage
+[[ -z $tags ]] && usage
+
+tags=$(echo $tags | sed -e 's/,/ /g')
+
+# TODO expose list of images as command line flag?
+images="init init_debug app app_debug runtime runtime_debug"
+
+if [[ "$hub" =~ ^gcr\.io ]]; then
+    gcloud docker --authorize-only
+fi
+
+set -ex
+
+for image in $images; do
+    for tag in $tags; do
+        bazel $BAZEL_ARGS run //docker:$image $hub/$image:$tag
+        docker push $hub/$image:$tag
+    done
+done


### PR DESCRIPTION
A similar scheme can be adopted for istio/proxy and istio/mixer once this is approved. The docker-release script could be generalized further by adding '--images' flag in which case the release script could be common to all components (via istio-testing?). Alternatively, if the release-docker script is kept in manager, developers can use to release their own set of test images without dependency on istio/istio-testing.