### PR TITLE
update debug base image

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -288,10 +288,12 @@ http_file(
 ## Docker rules
 ##
 
+DEBUG_BASE_IMAGE_SHA="3f57ae2aceef79e4000fb07ec850bbf4bce811e6f81dc8cfd970e16cdf33e622"
+
 http_file(
     name = "ubuntu_xenial_debug",
-    url = "https://storage.googleapis.com/istio-build/manager/ubuntu_xenial_debug.tar.gz",
-    sha256 = "02f0ea4b04012562dec4b75ee4337ac77a0003418d02a91bde1b4b4d162a41e4",
+    url = "https://storage.googleapis.com/istio-build/manager/ubuntu_xenial_debug-" + DEBUG_BASE_IMAGE_SHA + ".tar.gz",
+    sha256 = DEBUG_BASE_IMAGE_SHA
 )
 
 new_http_archive(

--- a/docker/debug/Dockerfile
+++ b/docker/debug/Dockerfile
@@ -9,7 +9,9 @@ RUN apt-get update && \
 	    curl \
 	    iptables \
 	    iproute2 \
-	    iputils-ping
+	    iputils-ping \
+	    dnsutils \
+	    netcat
 
 ADD proxy-redirection-clear /usr/local/bin/proxy-redirection-clear
 ADD proxy-redirection-restore /usr/local/bin/proxy-redirection-restore

--- a/docker/debug/build-and-publish-debug-image.sh
+++ b/docker/debug/build-and-publish-debug-image.sh
@@ -4,11 +4,11 @@ set -ex
 
 hub=gcr.io/istio-testing
 tag=ubuntu_xenial_debug
-filename=ubuntu_xenial_debug
+name=ubuntu_xenial_debug
 
 docker build . -t $hub:$tag
-docker save $hub:$tag | gzip > $filename.tar.gz
-gsutil cp $filename.tar.gz gs://istio-build/manager/$filename.tar.gz
-sum=$(sha256sum $filename.tar.gz)
+docker save $hub:$tag | gzip > $name.tar.gz
+sum=$(sha256sum $name.tar.gz | cut -f1 -d' ')
+gsutil cp $name.tar.gz gs://istio-build/manager/$name-$sum.tar.gz
 
-echo "Update the sha256 to $sum for the $filename http_file() rule in WORKSPACE"
+echo "Update DEBUG_BASE_IMAGE_SHA to $sum in WORKSPACE"


### PR DESCRIPTION
- encode sha256 in filename to make it easier to support multiple base
image revisions.
- add dnsutils and netcat to debug base image