### PR TITLE
Initialize Envoy at watcher creation

### DIFF
--- a/proxy/envoy/ingress.go
+++ b/proxy/envoy/ingress.go
@@ -47,6 +47,14 @@ func NewIngressWatcher(discovery model.ServiceDiscovery, ctl model.Controller,
 		mesh:      mesh,
 	}
 
+	// Initialize envoy according to the current model state,
+	// instead of waiting for the first event to arrive.
+	// Note that this is currently done synchronously (blocking),
+	// to avoid racing with controller events lurking around the corner.
+	// This can be improved once we switch to a mechanism where reloads
+	// are linearized (e.g., by a single goroutine reloader).
+	out.reload()
+
 	err := ctl.AppendConfigHandler(model.IngressRule,
 		func(model.Key, proto.Message, model.Event) { out.reload() })
 

--- a/proxy/envoy/watcher.go
+++ b/proxy/envoy/watcher.go
@@ -58,6 +58,14 @@ func NewWatcher(discovery model.ServiceDiscovery, ctl model.Controller,
 		addrs:     addrs,
 	}
 
+	// Initialize envoy according to the current model state,
+	// instead of waiting for the first event to arrive.
+	// Note that this is currently done synchronously (blocking),
+	// to avoid racing with controller events lurking around the corner.
+	// This can be improved once we switch to a mechanism where reloads
+	// are linearized (e.g., by a single goroutine reloader).
+	out.reload()
+
 	if err := ctl.AppendServiceHandler(func(*model.Service, model.Event) { out.reload() }); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Modify Envoy watchers (both ingress and sidecar) to `reload()` Envoy with configuration based on initial state, instead of waiting for the first event to arrive from the controller.

Note that this is currently done synchronously (blocking), to avoid racing with controller events lurking around the corner. This can be improved once we switch to a mechanism where reloads are linearized (e.g., by a single goroutine reloader).

Fixes #220.