### PR TITLE
Add TCP routing checks to e2e integration test

### DIFF
--- a/proxy/envoy/config.go
+++ b/proxy/envoy/config.go
@@ -262,7 +262,7 @@ func buildOutboundFilters(instances []*model.ServiceInstance, services []*model.
 				http.VirtualHosts = append(http.VirtualHosts, host)
 			case model.ProtocolTCP:
 				cluster := buildOutboundCluster(service.Hostname, port, nil)
-				route := buildTCPRoute(cluster, service.Address, port.Port)
+				route := buildTCPRoute(cluster, []string{service.Address}, port.Port)
 				config := tcpConfigs.EnsurePort(port.Port)
 				config.Routes = append(config.Routes, route)
 			default:
@@ -303,9 +303,11 @@ func buildInboundFilters(instances []*model.ServiceInstance) (HTTPRouteConfigs, 
 			http.VirtualHosts = append(http.VirtualHosts, host)
 		case model.ProtocolTCP:
 			cluster := buildInboundCluster(service.Hostname, endpoint.Port, port.Protocol)
-			route := buildTCPRoute(cluster, endpoint.Address, endpoint.Port)
 			config := tcpConfigs.EnsurePort(port.Port)
-			config.Routes = append(config.Routes, route)
+			config.Routes = append(config.Routes,
+				buildTCPRoute(cluster, []string{endpoint.Address}, endpoint.Port),
+				buildTCPRoute(cluster, []string{service.Address, endpoint.Address}, port.Port),
+			)
 		default:
 			glog.Warningf("Unsupported inbound protocol %v for port %d", port.Protocol, port)
 		}

--- a/proxy/envoy/config.go
+++ b/proxy/envoy/config.go
@@ -303,11 +303,13 @@ func buildInboundFilters(instances []*model.ServiceInstance) (HTTPRouteConfigs, 
 			http.VirtualHosts = append(http.VirtualHosts, host)
 		case model.ProtocolTCP:
 			cluster := buildInboundCluster(service.Hostname, endpoint.Port, port.Protocol)
+
+			// Omit destination port from TCP route since inbound TCP
+			// routes are already mapped to a listener on a specific
+			// port.
+			route := buildTCPRoute(cluster, []string{endpoint.Address, service.Address}, -1)
 			config := tcpConfigs.EnsurePort(port.Port)
-			config.Routes = append(config.Routes,
-				buildTCPRoute(cluster, []string{endpoint.Address}, endpoint.Port),
-				buildTCPRoute(cluster, []string{service.Address, endpoint.Address}, port.Port),
-			)
+			config.Routes = append(config.Routes, route)
 		default:
 			glog.Warningf("Unsupported inbound protocol %v for port %d", port.Protocol, port)
 		}

--- a/proxy/envoy/config.go
+++ b/proxy/envoy/config.go
@@ -286,12 +286,13 @@ func buildInboundFilters(instances []*model.ServiceInstance) (HTTPRouteConfigs, 
 	for _, instance := range instances {
 		service := instance.Service
 		endpoint := instance.Endpoint
-		port := endpoint.ServicePort
-		switch port.Protocol {
+		servicePort := endpoint.ServicePort
+		protocol := servicePort.Protocol
+		switch protocol {
 		case model.ProtocolHTTP, model.ProtocolHTTP2, model.ProtocolGRPC:
-			cluster := buildInboundCluster(service.Hostname, endpoint.Port, port.Protocol)
+			cluster := buildInboundCluster(service.Hostname, endpoint.Port, protocol)
 			route := buildDefaultRoute(cluster)
-			host := buildVirtualHost(service, port, suffix, []*HTTPRoute{route})
+			host := buildVirtualHost(service, servicePort, suffix, []*HTTPRoute{route})
 
 			// insert explicit instance ip:port as a hostname field
 			host.Domains = append(host.Domains, fmt.Sprintf("%s:%d", endpoint.Address, endpoint.Port))
@@ -302,16 +303,34 @@ func buildInboundFilters(instances []*model.ServiceInstance) (HTTPRouteConfigs, 
 			http := httpConfigs.EnsurePort(endpoint.Port)
 			http.VirtualHosts = append(http.VirtualHosts, host)
 		case model.ProtocolTCP:
-			cluster := buildInboundCluster(service.Hostname, endpoint.Port, port.Protocol)
+			cluster := buildInboundCluster(service.Hostname, endpoint.Port, protocol)
 
-			// Omit destination port from TCP route since inbound TCP
-			// routes are already mapped to a listener on a specific
+			// Local services can be accessed at one of three
+			// addresses: localhost, endpoint IP, and service
+			// VIP. Localhost bypasses the proxy and doesn't need any TCP
+			// route config. Endpoint IP and Service VIP access is
+			// handled below.
+			//
+			// Omit the destination port here since TCP routes are
+			// already declared in the scope of a particular listener
 			// port.
-			route := buildTCPRoute(cluster, []string{endpoint.Address, service.Address}, -1)
-			config := tcpConfigs.EnsurePort(port.Port)
-			config.Routes = append(config.Routes, route)
+
+			// Traffic sent to our service VIP is redirected by remote
+			// services' kubeproxy to our specific endpoint IP.
+			config := tcpConfigs.EnsurePort(endpoint.Port)
+			config.Routes = append(config.Routes,
+				buildTCPRoute(cluster, []string{endpoint.Address}, -1),
+			)
+
+			// Traffic sent to our service VIP by a container
+			// co-located in our same pod will be intercepted by envoy
+			// proxy before it is redirected to the endpoint IP.
+			config = tcpConfigs.EnsurePort(servicePort.Port)
+			config.Routes = append(config.Routes,
+				buildTCPRoute(cluster, []string{service.Address}, -1),
+			)
 		default:
-			glog.Warningf("Unsupported inbound protocol %v for port %d", port.Protocol, port)
+			glog.Warningf("Unsupported inbound protocol %v for port %d", protocol, servicePort)
 		}
 	}
 

--- a/proxy/envoy/route.go
+++ b/proxy/envoy/route.go
@@ -238,11 +238,14 @@ func sharedHost(parts ...[]string) []string {
 	}
 }
 
-func buildTCPRoute(cluster *Cluster, address string, port int) TCPRoute {
-	return TCPRoute{
-		Cluster:           cluster.Name,
-		DestinationIPList: []string{address + "/32"},
-		DestinationPorts:  strconv.Itoa(port),
-		clusterRef:        cluster,
+func buildTCPRoute(cluster *Cluster, addresses []string, port int) TCPRoute {
+	route := TCPRoute{
+		Cluster:          cluster.Name,
+		DestinationPorts: strconv.Itoa(port),
+		clusterRef:       cluster,
 	}
+	for _, addr := range addresses {
+		route.DestinationIPList = append(route.DestinationIPList, addr+"/32")
+	}
+	return route
 }

--- a/proxy/envoy/route.go
+++ b/proxy/envoy/route.go
@@ -240,9 +240,11 @@ func sharedHost(parts ...[]string) []string {
 
 func buildTCPRoute(cluster *Cluster, addresses []string, port int) TCPRoute {
 	route := TCPRoute{
-		Cluster:          cluster.Name,
-		DestinationPorts: strconv.Itoa(port),
-		clusterRef:       cluster,
+		Cluster:    cluster.Name,
+		clusterRef: cluster,
+	}
+	if port >= 0 {
+		route.DestinationPorts = strconv.Itoa(port)
 	}
 	for _, addr := range addresses {
 		route.DestinationIPList = append(route.DestinationIPList, addr+"/32")

--- a/proxy/envoy/testdata/envoy.json.golden
+++ b/proxy/envoy/testdata/envoy.json.golden
@@ -174,6 +174,14 @@
                   "destination_ports": "1090"
                 },
                 {
+                  "cluster": "inbound:1090",
+                  "destination_ip_list": [
+                    "10.1.0.0/32",
+                    "10.1.1.0/32"
+                  ],
+                  "destination_ports": "90"
+                },
+                {
                   "cluster": "outbound:world.default.svc.cluster.local:custom",
                   "destination_ip_list": [
                     "10.2.0.0/32"

--- a/proxy/envoy/testdata/envoy.json.golden
+++ b/proxy/envoy/testdata/envoy.json.golden
@@ -169,17 +169,9 @@
                 {
                   "cluster": "inbound:1090",
                   "destination_ip_list": [
-                    "10.1.1.0/32"
-                  ],
-                  "destination_ports": "1090"
-                },
-                {
-                  "cluster": "inbound:1090",
-                  "destination_ip_list": [
-                    "10.1.0.0/32",
-                    "10.1.1.0/32"
-                  ],
-                  "destination_ports": "90"
+                    "10.1.1.0/32",
+                    "10.1.0.0/32"
+                  ]
                 },
                 {
                   "cluster": "outbound:world.default.svc.cluster.local:custom",

--- a/proxy/envoy/testdata/envoy.json.golden
+++ b/proxy/envoy/testdata/envoy.json.golden
@@ -169,9 +169,9 @@
                 {
                   "cluster": "inbound:1090",
                   "destination_ip_list": [
-                    "10.1.1.0/32",
                     "10.1.0.0/32"
-                  ]
+                  ],
+                  "destination_ports": "90"
                 },
                 {
                   "cluster": "outbound:world.default.svc.cluster.local:custom",
@@ -237,6 +237,30 @@
                 "path": "/dev/stdout"
               }
             ]
+          }
+        }
+      ],
+      "bind_to_port": false
+    },
+    {
+      "port": 1090,
+      "filters": [
+        {
+          "type": "read",
+          "name": "tcp_proxy",
+          "config": {
+            "stat_prefix": "tcp",
+            "route_config": {
+              "routes": [
+                {
+                  "cluster": "inbound:1090",
+                  "destination_ip_list": [
+                    "10.1.1.0/32"
+                  ],
+                  "destination_ports": "1090"
+                }
+              ]
+            }
           }
         }
       ],

--- a/proxy/envoy/testdata/envoy.json.golden
+++ b/proxy/envoy/testdata/envoy.json.golden
@@ -170,8 +170,7 @@
                   "cluster": "inbound:1090",
                   "destination_ip_list": [
                     "10.1.0.0/32"
-                  ],
-                  "destination_ports": "90"
+                  ]
                 },
                 {
                   "cluster": "outbound:world.default.svc.cluster.local:custom",
@@ -256,8 +255,7 @@
                   "cluster": "inbound:1090",
                   "destination_ip_list": [
                     "10.1.1.0/32"
-                  ],
-                  "destination_ports": "1090"
+                  ]
                 }
               ]
             }

--- a/test/integration/app-proxy-manager-agent.yaml.tmpl
+++ b/test/integration/app-proxy-manager-agent.yaml.tmpl
@@ -13,6 +13,12 @@ spec:
   - port: 8080
     targetPort: {{.port2}}
     name: http-alternative
+  - port: 90
+    targetPort: {{.port3}}
+    name: tcp
+  - port: 9090
+    targetPort: {{.port4}}
+    name: tcp-alternative
   selector:
     app: {{.service}}
 ---
@@ -45,11 +51,17 @@ spec:
           - "{{.port1}}"
           - --port
           - "{{.port2}}"
+          - --port
+          - "{{.port3}}"
+          - --port
+          - "{{.port4}}"
           - --version
           - "{{.version}}"
         ports:
         - containerPort: {{.port1}}
         - containerPort: {{.port2}}
+        - containerPort: {{.port3}}
+        - containerPort: {{.port4}}
       - name: proxy
         image: {{.hub}}/runtime:{{.tag}}
         imagePullPolicy: Always

--- a/test/integration/app.yaml.tmpl
+++ b/test/integration/app.yaml.tmpl
@@ -13,6 +13,12 @@ spec:
   - port: 8080
     targetPort: {{.port2}}
     name: http-alternative
+  - port: 90
+    targetPort: {{.port3}}
+    name: tcp
+  - port: 9090
+    targetPort: {{.port4}}
+    name: tcp-alternative
   selector:
     app: {{.name}}
 ---
@@ -36,9 +42,15 @@ spec:
           - "{{.port1}}"
           - --port
           - "{{.port2}}"
+          - --port
+          - "{{.port3}}"
+          - --port
+          - "{{.port4}}"
           - --version
           - "{{.version}}"
         ports:
         - containerPort: {{.port1}}
         - containerPort: {{.port2}}
+        - containerPort: {{.port3}}
+        - containerPort: {{.port4}}
 ---

--- a/test/integration/driver.go
+++ b/test/integration/driver.go
@@ -127,17 +127,17 @@ func setup() {
 	pods = make(map[string]string)
 
 	// deploy istio-infra
-	check(deploy("http-discovery", "http-discovery", managerDiscovery, "8080", "80", "unversioned"))
-	check(deploy("mixer", "mixer", mixer, "8080", "80", "unversioned"))
-	check(deploy("istio-egress", "istio-egress", egressProxy, "8080", "80", "unversioned"))
+	check(deploy("http-discovery", "http-discovery", managerDiscovery, "8080", "80", "9090", "90", "unversioned"))
+	check(deploy("mixer", "mixer", mixer, "8080", "80", "9090", "90", "unversioned"))
+	check(deploy("istio-egress", "istio-egress", egressProxy, "8080", "80", "9090", "90", "unversioned"))
 
 	// deploy a healthy mix of apps, with and without proxy
-	check(deploy("t", "t", app, "8080", "80", "unversioned"))
-	check(deploy("a", "a", appProxyManagerAgent, "8080", "80", "unversioned"))
-	check(deploy("b", "b", appProxyManagerAgent, "80", "8080", "unversioned"))
-	check(deploy("hello", "hello", appProxyManagerAgent, "8080", "80", "v1"))
-	check(deploy("world-v1", "world", appProxyManagerAgent, "80", "8000", "v1"))
-	check(deploy("world-v2", "world", appProxyManagerAgent, "80", "8000", "v2"))
+	check(deploy("t", "t", app, "8080", "80", "9090", "90", "unversioned"))
+	check(deploy("a", "a", appProxyManagerAgent, "8080", "80", "9090", "90", "unversioned"))
+	check(deploy("b", "b", appProxyManagerAgent, "80", "8080", "90", "9090", "unversioned"))
+	check(deploy("hello", "hello", appProxyManagerAgent, "8080", "80", "9090", "90", "v1"))
+	check(deploy("world-v1", "world", appProxyManagerAgent, "80", "8000", "90", "9090", "v1"))
+	check(deploy("world-v2", "world", appProxyManagerAgent, "80", "8000", "90", "9090", "v2"))
 	check(setPods())
 }
 
@@ -161,7 +161,7 @@ func teardown() {
 	}
 }
 
-func deploy(name, svcName, dType, port1, port2, version string) error {
+func deploy(name, svcName, dType, port1, port2, port3, port4, version string) error {
 	// write template
 	configFile := name + "-" + dType + ".yaml"
 	var w *bufio.Writer
@@ -182,6 +182,8 @@ func deploy(name, svcName, dType, port1, port2, version string) error {
 		"name":    name,
 		"port1":   port1,
 		"port2":   port2,
+		"port3":   port3,
+		"port4":   port4,
 		"version": version,
 	}, w); err != nil {
 		return err

--- a/test/integration/reachability.go
+++ b/test/integration/reachability.go
@@ -46,6 +46,11 @@ func (r *reachability) run() error {
 	if err := r.makeRequests(); err != nil {
 		return err
 	}
+
+	if err := r.verifyTCPRouting(); err != nil {
+		return err
+	}
+
 	if verbose {
 		log.Println("requests:", r.accessLogs)
 	}
@@ -55,10 +60,6 @@ func (r *reachability) run() error {
 	}
 
 	if err := r.checkMixerLogs(); err != nil {
-		return err
-	}
-
-	if err := r.verifyTCPRouting(); err != nil {
 		return err
 	}
 

--- a/test/integration/reachability.go
+++ b/test/integration/reachability.go
@@ -43,19 +43,22 @@ func (r *reachability) run() error {
 		r.accessLogs[app] = make([]string, 0)
 	}
 
-	err := r.makeRequests()
-	if err != nil {
+	if err := r.makeRequests(); err != nil {
 		return err
 	}
 	if verbose {
 		log.Println("requests:", r.accessLogs)
 	}
 
-	if err = r.checkAccessLogs(); err != nil {
+	if err := r.checkAccessLogs(); err != nil {
 		return err
 	}
 
-	if err = r.checkMixerLogs(); err != nil {
+	if err := r.checkMixerLogs(); err != nil {
+		return err
+	}
+
+	if err := r.verifyTCPRouting(); err != nil {
 		return err
 	}
 
@@ -196,4 +199,62 @@ func (r *reachability) checkMixerLogs() error {
 		time.Sleep(time.Second)
 	}
 	return fmt.Errorf("exceeded budget for checking mixer logs")
+}
+
+func (r *reachability) makeTCPRequest(src, dst, port, domain string, done func() bool) func() error {
+	return func() error {
+		url := fmt.Sprintf("http://%s%s%s/%s", dst, domain, port, src)
+		for n := 0; n < budget; n++ {
+			log.Printf("Making a request %s from %s (attempt %d)...\n", url, src, n)
+			request, err := shell(fmt.Sprintf("kubectl exec %s -n %s -c app client %s",
+				pods[src], params.namespace, url), verbose)
+			if err != nil {
+				return err
+			}
+			match := regexp.MustCompile("StatusCode=(.*)").FindStringSubmatch(request)
+			if len(match) > 1 && match[1] == "200" {
+				return nil
+			}
+			if done() {
+				return nil
+			}
+		}
+		return fmt.Errorf("failed to verify TCP routing from %s to %s (url %s)", src, dst, url)
+	}
+}
+
+func (r *reachability) verifyTCPRouting() error {
+	log.Printf("verifyTCPRouting parallel=%t\n", parallel)
+	g, ctx := errgroup.WithContext(context.Background())
+	testPods := []string{"a", "b", "t"}
+	for _, src := range testPods {
+		for _, dst := range testPods {
+			for _, port := range []string{":90", ":9090"} {
+				for _, domain := range []string{"", "." + params.namespace} {
+					if parallel {
+						g.Go(r.makeTCPRequest(src, dst, port, domain, func() bool {
+							select {
+							case <-time.After(time.Second):
+								// try again
+							case <-ctx.Done():
+								return true
+							}
+							return false
+
+						}))
+					} else {
+						if err := r.makeTCPRequest(src, dst, port, domain, func() bool { return false })(); err != nil {
+							return err
+						}
+					}
+				}
+			}
+		}
+	}
+	if parallel {
+		if err := g.Wait(); err != nil {
+			return err
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
Use existing HTTP server/client to verify TCP routing rules by setting
up k8s services with non-http port names (e.g. tcp, tcp-alternative).

This also fixes bug in inbound TCP route construction by adding
ServiceAddress:ServicePort and EndpointAddress:ServicePort in addition
to EndpointAddress:Port.