### PR TITLE
Use KUBECONFIG env variable if defined

### DIFF
--- a/cmd/istioctl/istioctl_test.go
+++ b/cmd/istioctl/istioctl_test.go
@@ -86,3 +86,10 @@ func TestCreateReplaceDeletePolicy(t *testing.T) {
 		t.Fatalf("Second attempt to delete destination policy did not fail")
 	}
 }
+
+func TestBogusExplicitKubeConfig(t *testing.T) {
+	cmd.RootFlags.Kubeconfig = "/dummy/does-not-exist.yaml"
+	if err := cmd.RootCmd.PersistentPreRunE(postCmd, []string{}); err == nil { // Set up Client
+		t.Fatalf("Did not fail setting up client with bogus kubeconfig: %v", err)
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -48,13 +48,21 @@ var (
 		Short: "Istio Manager",
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) (err error) {
 			glog.V(2).Infof("Root flags: %#v", RootFlags)
-			Client, err = kube.NewClient(RootFlags.Kubeconfig, model.IstioConfig)
-			if err != nil {
-				Client, err = kube.NewClient(os.Getenv("HOME")+"/.kube/config", model.IstioConfig)
-				if err != nil {
-					return multierror.Prefix(err, "failed to connect to Kubernetes API.")
+
+			if RootFlags.Kubeconfig == "" {
+				if os.Getenv("KUBECONFIG") != "" {
+					glog.V(2).Infof("Setting configuration from KUBECONFIG environment variable")
+					RootFlags.Kubeconfig = os.Getenv("KUBECONFIG")
+				} else {
+					RootFlags.Kubeconfig = os.Getenv("HOME")+"/.kube/config"
 				}
 			}
+
+			Client, err = kube.NewClient(RootFlags.Kubeconfig, model.IstioConfig)
+			if err != nil {
+				return multierror.Prefix(err, "failed to connect to Kubernetes API.")
+			}
+
 			if err = Client.RegisterResources(); err != nil {
 				return multierror.Prefix(err, "failed to register Third-Party Resources.")
 			}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -54,7 +54,7 @@ var (
 					glog.V(2).Infof("Setting configuration from KUBECONFIG environment variable")
 					RootFlags.Kubeconfig = os.Getenv("KUBECONFIG")
 				} else {
-					RootFlags.Kubeconfig = os.Getenv("HOME")+"/.kube/config"
+					RootFlags.Kubeconfig = os.Getenv("HOME") + "/.kube/config"
 				}
 			}
 


### PR DESCRIPTION
If --kubeconfig is not defined use $KUBECONFIG as the default.  Only fall back to ~/.kube/config if neither are provided

If --kubeconfig or $KUBECONFIG are provided, but the configuration cannot be opened, fail rather than silently switching to ~/.kube/config