### PR TITLE
Support HTTPS

### DIFF
--- a/bin/init.sh
+++ b/bin/init.sh
@@ -7,7 +7,5 @@ bin/bazel_to_go.py > /dev/null
 # Remove doubly-vendorized k8s dependencies
 rm -rf vendor/k8s.io/client-go/vendor
 
+# Some linters expect the code to be installed
 go install ./...
-go get -u github.com/alecthomas/gometalinter
-go get -u github.com/bazelbuild/buildifier/buildifier
-gometalinter --install --vendored-linters

--- a/bin/install-prereqs.sh
+++ b/bin/install-prereqs.sh
@@ -2,3 +2,10 @@
 
 # Install mockgen tool to generate golang mock interfaces
 go get github.com/golang/mock/mockgen
+
+# Install linters
+go get -u github.com/alecthomas/gometalinter
+gometalinter --install --vendored-linters
+
+# Install buildifier BUILD file validator
+go get -u github.com/bazelbuild/buildifier/buildifier

--- a/cmd/istioctl/BUILD
+++ b/cmd/istioctl/BUILD
@@ -27,7 +27,8 @@ go_prefix("istio.io/manager")
 go_test(
     name = "go_default_test",
     srcs = ["istioctl_test.go"],
-    data = glob(["testdata/*.yaml"]) +
-        ["//platform/kube:kubeconfig"],
+    data = glob(["testdata/*.yaml"]) + [
+        "//platform/kube:kubeconfig",
+    ],
     library = ":go_default_library",
 )

--- a/cmd/istioctl/BUILD
+++ b/cmd/istioctl/BUILD
@@ -27,6 +27,7 @@ go_prefix("istio.io/manager")
 go_test(
     name = "go_default_test",
     srcs = ["istioctl_test.go"],
-    data = glob(["testdata/*.yaml"]),
+    data = glob(["testdata/*.yaml"]) +
+        ["//platform/kube:kubeconfig"],
     library = ":go_default_library",
 )

--- a/cmd/istioctl/istioctl_test.go
+++ b/cmd/istioctl/istioctl_test.go
@@ -20,7 +20,15 @@ import (
 	"istio.io/manager/cmd"
 )
 
+func rootSetup(t *testing.T) {
+	cmd.RootFlags.Kubeconfig = "../../platform/kube/config"
+	if err := cmd.RootCmd.PersistentPreRunE(postCmd, []string{}); err != nil { // Set up Client
+		t.Fatalf("Could not set up root command: %v", err)
+	}
+}
+
 func TestCreateInvalidFile(t *testing.T) {
+	rootSetup(t)
 	file = "does-not-exist.yaml"
 	if err := postCmd.RunE(postCmd, []string{}); err == nil {
 		t.Fatalf("Did not fail looking for file")
@@ -28,6 +36,7 @@ func TestCreateInvalidFile(t *testing.T) {
 }
 
 func TestInvalidType(t *testing.T) {
+	rootSetup(t)
 	file = "testdata/invalid-type.yaml"
 	if err := postCmd.RunE(postCmd, []string{}); err == nil {
 		t.Fatalf("Did not fail when presented with invalid rule type")
@@ -35,6 +44,7 @@ func TestInvalidType(t *testing.T) {
 }
 
 func TestInvalidRuleStructure(t *testing.T) {
+	rootSetup(t)
 	file = "testdata/invalid-dest-policy.yaml"
 	if err := postCmd.RunE(postCmd, []string{}); err == nil {
 		t.Fatalf("Did not fail when presented with invalid rule structure")
@@ -42,10 +52,8 @@ func TestInvalidRuleStructure(t *testing.T) {
 }
 
 func TestCreateReplaceDeleteRoutes(t *testing.T) {
+	rootSetup(t)
 	file = "testdata/four-route-rules.yaml"
-	if err := cmd.RootCmd.PersistentPreRunE(postCmd, []string{}); err != nil { // Set up Client
-		t.Fatalf("Could not set up root command: %v", err)
-	}
 	if err := postCmd.RunE(postCmd, []string{}); err != nil {
 		t.Fatalf("Could not create routes: %v", err)
 	}
@@ -65,10 +73,8 @@ func TestCreateReplaceDeleteRoutes(t *testing.T) {
 }
 
 func TestCreateReplaceDeletePolicy(t *testing.T) {
+	rootSetup(t)
 	file = "testdata/dest-policy.yaml"
-	if err := cmd.RootCmd.PersistentPreRunE(postCmd, []string{}); err != nil { // Set up Client
-		t.Fatalf("Could not set up root command: %v", err)
-	}
 	if err := postCmd.RunE(postCmd, []string{}); err != nil {
 		t.Fatalf("Could not create destination policy: %v", err)
 	}

--- a/cmd/istioctl/main.go
+++ b/cmd/istioctl/main.go
@@ -63,7 +63,7 @@ var (
 				return err
 			}
 			if len(varr) == 0 {
-				return errors.New("Nothing to create")
+				return errors.New("nothing to create")
 			}
 			for _, v := range varr {
 				if err = setup(v.Type, v.Name); err != nil {
@@ -92,7 +92,7 @@ var (
 				return err
 			}
 			if len(varr) == 0 {
-				return errors.New("Nothing to replace")
+				return errors.New("nothing to replace")
 			}
 			for _, v := range varr {
 				if err = setup(v.Type, v.Name); err != nil {
@@ -162,7 +162,7 @@ var (
 				return err
 			}
 			if len(varr) == 0 {
-				return errors.New("Nothing to delete")
+				return errors.New("nothing to delete")
 			}
 			for _, v := range varr {
 				if err = setup(v.Type, v.Name); err != nil {
@@ -296,12 +296,12 @@ func readInputs() ([]inputDoc, error) {
 		// Do a second decode pass, to get the data into structured format
 		byteRule, err := json.Marshal(v.Spec)
 		if err != nil {
-			return nil, fmt.Errorf("Could not encode Spec: %v", err)
+			return nil, fmt.Errorf("could not encode Spec: %v", err)
 		}
 
 		schema, ok := model.IstioConfig[v.Type]
 		if !ok {
-			return nil, fmt.Errorf("Unknown spec type %s", v.Type)
+			return nil, fmt.Errorf("unknown spec type %s", v.Type)
 		}
 		rr, err := schema.FromJSON(string(byteRule))
 		if err != nil {

--- a/doc/build-vagrant.md
+++ b/doc/build-vagrant.md
@@ -5,7 +5,7 @@ _Note:_ This section applies to Mac and Windows users only. You can develop nati
 
 ## Pre-requisites ##
 
-- Setup Go 1.7.5+ on your host machine
+- Setup Go 1.8+ on your host machine
 - Clone this repository
 - Install [Virtualbox](https://github.com/kubernetes/minikube/releases)
 - Install [Minikube](https://github.com/kubernetes/minikube/releases)

--- a/doc/build.md
+++ b/doc/build.md
@@ -4,9 +4,9 @@
 
 Install additional build dependencies before trying to build.
 
-    sh bin/install-prereqs.sh
+    bin/install-prereqs.sh
 
-We are using [Bazel 0.4.4](https://github.com/bazelbuild/bazel/releases) as the main build system in Istio Manager. The following commands builds all targets in Istio Manager:
+We are using [Bazel 0.4.4](https://github.com/bazelbuild/bazel/releases) as the main build system in Istio Manager. The following command builds all targets in Istio Manager:
 
     bazel build //:all
 
@@ -25,11 +25,13 @@ try to update the mlocate database and run `locate gazelle`.
 
 ## Go tooling compatibility
 
+Istio Manager requires Go1.8+ toolchain.
+
 Bazel build environment is compatible with the standard Golang tooling, except you need to vendorize all dependencies in Istio Manager. If you have successfully built with Bazel, run the following script to put dependencies fetched by Bazel into `vendor` directory:
 
     bin/init.sh
 
-After running this command, you should be able to use standard go tools:
+After running this command, you should be able to use all standard go tools:
 
     go generate istio.io/manager/...
     go build istio.io/manager/...

--- a/model/config_test.go
+++ b/model/config_test.go
@@ -368,9 +368,9 @@ func TestIstioRegistryRouteAndIngressRules(t *testing.T) {
 		{
 			name: "Slice of unsorted RouteRules",
 			mockObjs: map[Key]proto.Message{
-				Key{Kind: "foo"}: routeRule1MatchNil,
-				Key{Kind: "bar"}: routeRule3SourceMismatch,
-				Key{Kind: "baz"}: routeRule2SourceEmpty,
+				{Kind: "foo"}: routeRule1MatchNil,
+				{Kind: "bar"}: routeRule3SourceMismatch,
+				{Kind: "baz"}: routeRule2SourceEmpty,
 			},
 			want: []*proxyconfig.RouteRule{
 				routeRule1MatchNil,
@@ -409,12 +409,12 @@ func TestIstioRegistryRouteRulesBySource(t *testing.T) {
 	instances := []*ServiceInstance{serviceInstance1, serviceInstance2}
 
 	mockObjs := map[Key]proto.Message{
-		Key{Kind: "match-nil"}:              routeRule1MatchNil,
-		Key{Kind: "source-empty"}:           routeRule2SourceEmpty,
-		Key{Kind: "source-mismatch"}:        routeRule3SourceMismatch,
-		Key{Kind: "source-match"}:           routeRule4SourceMatch,
-		Key{Kind: "tag-subset-of-mismatch"}: routeRule5TagSubsetOfMismatch,
-		Key{Kind: "tag-subset-of-match"}:    routeRule6TagSubsetOfMatch,
+		{Kind: "match-nil"}:              routeRule1MatchNil,
+		{Kind: "source-empty"}:           routeRule2SourceEmpty,
+		{Kind: "source-mismatch"}:        routeRule3SourceMismatch,
+		{Kind: "source-match"}:           routeRule4SourceMatch,
+		{Kind: "tag-subset-of-mismatch"}: routeRule5TagSubsetOfMismatch,
+		{Kind: "tag-subset-of-match"}:    routeRule6TagSubsetOfMatch,
 	}
 	want := []*proxyconfig.RouteRule{
 		routeRule6TagSubsetOfMatch,
@@ -449,9 +449,9 @@ func TestIstioRegistryPoliciesByNamespace(t *testing.T) {
 		{
 			name: "Slice of unsorted DestinationPolicy",
 			mockObjs: map[Key]proto.Message{
-				Key{Kind: "foo"}: dstPolicy1,
-				Key{Kind: "bar"}: dstPolicy2,
-				Key{Kind: "baz"}: dstPolicy3,
+				{Kind: "foo"}: dstPolicy1,
+				{Kind: "bar"}: dstPolicy2,
+				{Kind: "baz"}: dstPolicy3,
 			},
 			want: []*proxyconfig.DestinationPolicy{
 				dstPolicy1, dstPolicy2, dstPolicy3,
@@ -479,10 +479,10 @@ func TestIstioRegistryDestinationPolicies(t *testing.T) {
 	defer r.shutdown()
 
 	mockObjs := map[Key]proto.Message{
-		Key{Kind: "foo"}:  dstPolicy1,
-		Key{Kind: "foo2"}: dstPolicy2,
-		Key{Kind: "bar"}:  dstPolicy3,
-		Key{Kind: "baz"}:  dstPolicy4,
+		{Kind: "foo"}:  dstPolicy1,
+		{Kind: "foo2"}: dstPolicy2,
+		{Kind: "bar"}:  dstPolicy3,
+		{Kind: "baz"}:  dstPolicy4,
 	}
 	want := []*proxyconfig.DestinationPolicy{dstPolicy1}
 

--- a/model/service.go
+++ b/model/service.go
@@ -113,7 +113,7 @@ type NetworkEndpoint struct {
 	// Port declaration from the service declaration This is the port for
 	// the service associated with this instance (e.g.,
 	// catalog.mystore.com)
-	ServicePort *Port `json:"port"`
+	ServicePort *Port `json:"service_port"`
 }
 
 // Tags is a non empty set of arbitrary strings. Each version of a service can

--- a/proxy/envoy/config.go
+++ b/proxy/envoy/config.go
@@ -39,8 +39,6 @@ import (
 // - lists in the config must be de-duplicated and ordered in a canonical way
 
 // TODO: missing features in the config generation:
-// - TCP routing
-// - HTTPS protocol for inbound and outbound configuration using TCP routing or SNI
 // - HTTP pod port collision creates duplicate virtual host entries
 // - (bug) two service ports with the same target port create two virtual hosts with same domains
 //   (not allowed by envoy). FIXME - need to detect and eliminate such ports in validation
@@ -299,7 +297,7 @@ func buildOutboundRoutes(instances []*model.ServiceInstance, services []*model.S
 				http := httpConfigs.EnsurePort(port.Port)
 				http.VirtualHosts = append(http.VirtualHosts, host)
 
-			case model.ProtocolTCP:
+			case model.ProtocolTCP, model.ProtocolHTTPS:
 				cluster := buildOutboundCluster(service.Hostname, port, nil)
 				route := buildTCPRoute(cluster, []string{service.Address}, port.Port)
 				config := tcpConfigs.EnsurePort(port.Port)
@@ -343,7 +341,7 @@ func buildInboundRoutes(instances []*model.ServiceInstance) (HTTPRouteConfigs, T
 			http := httpConfigs.EnsurePort(endpoint.Port)
 			http.VirtualHosts = append(http.VirtualHosts, host)
 
-		case model.ProtocolTCP:
+		case model.ProtocolTCP, model.ProtocolHTTPS:
 			cluster := buildInboundCluster(service.Hostname, endpoint.Port, protocol)
 
 			// Local service instances can be accessed through one of three

--- a/test/integration/app-proxy-manager-agent.yaml.tmpl
+++ b/test/integration/app-proxy-manager-agent.yaml.tmpl
@@ -18,7 +18,7 @@ spec:
     name: tcp
   - port: 9090
     targetPort: {{.port4}}
-    name: tcp-alternative
+    name: https
   selector:
     app: {{.service}}
 ---

--- a/test/integration/driver.go
+++ b/test/integration/driver.go
@@ -152,6 +152,7 @@ func check(err error) {
 func teardown() {
 	if verbose {
 		log.Print(podLogs(pods["a"], "proxy"))
+		log.Print(podLogs(pods["b"], "proxy"))
 	}
 	if nameSpaceCreated {
 		deleteNamespace(client, params.namespace)


### PR DESCRIPTION
Treat HTTPS as opaque TCP traffic.

Build fixes:
* organize init scripts
* document go1.8 as a requirement
* start errors with lower case 
* fix istioctl test dependency