### PR TITLE
add per-image tar option to manager_docker_build

### DIFF
--- a/docker/BUILD
+++ b/docker/BUILD
@@ -75,16 +75,21 @@ manager_docker_build(
         {
             "name": "runtime",
             "base": "@docker_ubuntu//:xenial",
+            "tars": [
+              "@istio_proxy//file",
+            ],
         },
         {
             "name": "runtime_debug",
             "base": "@ubuntu_xenial_debug//file",
+            "tars": [
+              "@istio_proxy_debug//file",
+            ],
         },
     ],
     repository = "istio",
     tags = ["manual"],
     tars = [
-        "@istio_proxy//file",
         ":manager",
         ":config",
     ],

--- a/docker/manager_docker.bzl
+++ b/docker/manager_docker.bzl
@@ -1,9 +1,15 @@
 load("@bazel_tools//tools/build_defs/docker:docker.bzl", "docker_build")
 
 def manager_docker_build(images, **kwargs):
+    common_tars = kwargs.pop('tars', [])
+
     for image in images:
+        tars = image.pop('tars', [])
+        tars.extend(common_tars)
+
         docker_build(
             name = image['name'],
             base = image['base'],
+            tars = tars,
             **kwargs
         )


### PR DESCRIPTION
github.com/istio/manager/pull/197 inadvertently removed
istio_debug_proxy as a dependency for runtime_debug. Add a option to
specify per-image tars to the manager_docker_build rule so different
layers can be specified for release and debug docker targets.

ref https://github.com/istio/manager/issues/316