### PR TITLE
Add init script parameters

### DIFF
--- a/docker/prepare_proxy.sh
+++ b/docker/prepare_proxy.sh
@@ -1,15 +1,48 @@
 #!/bin/bash
+# Proxy initialization script responsible for setting up port forwarding.
 
-set -e 
+set -o errexit
+set -o nounset
+set -o pipefail
 
-# TODO Hardcoded to match user defined deployment/pod specs and istio proxy
-# configuration. Optionally pull this from ConfigMap to dynamically coordinate
-# uid and port management with proxy (re)start and config.
-ISTIO_PROXY_PORT=5001
-ISTIO_PROXY_UID=1337
+usage() {
+  echo "${0} -p PORT -u UID [-h]"
+  echo ''
+  echo '  -p: Specify the proxy port to which redirect all TCP traffic'
+  echo '  -u: Specify the UID of the user for which the redirection is not'
+  echo '      applied. Typically, this is the UID of the proxy container'
+  echo ''
+}
 
-iptables -t nat -A PREROUTING -p tcp -j REDIRECT --to-port $ISTIO_PROXY_PORT
-iptables -t nat -A OUTPUT -p tcp -j REDIRECT ! -s 127.0.0.1/32 --to-port $ISTIO_PROXY_PORT -m owner '!' --uid-owner $ISTIO_PROXY_UID
+while getopts ":p:u:h" opt; do
+  case ${opt} in
+    p)
+      ISTIO_PROXY_PORT=${OPTARG}
+      ;;
+    u)
+      ISTIO_PROXY_UID=${OPTARG}
+      ;;
+    h)
+      usage
+      exit 0
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "${ISTIO_PROXY_PORT-}" ]] || [[ -z "${ISTIO_PROXY_UID-}" ]]; then
+  echo "Please set both -p and -u parameters"
+  usage
+  exit 1
+fi
+
+iptables -t nat -A PREROUTING -p tcp -j REDIRECT --to-port ${ISTIO_PROXY_PORT}
+iptables -t nat -A OUTPUT -p tcp -j REDIRECT ! -s 127.0.0.1/32 \
+  --to-port ${ISTIO_PROXY_PORT} -m owner '!' --uid-owner ${ISTIO_PROXY_UID}
 
 # Enable core dumps to writable directory
 sysctl -w  kernel.core_pattern=/tmp/core.%e.%p.%t

--- a/proxy/envoy/resources.go
+++ b/proxy/envoy/resources.go
@@ -41,8 +41,8 @@ var (
 	DefaultMeshConfig = &MeshConfig{
 		DiscoveryAddress: "manager:8080",
 		MixerAddress:     "mixer:9091",
-		ProxyPort:        5001,
-		AdminPort:        5000,
+		ProxyPort:        15001,
+		AdminPort:        15000,
 		BinaryPath:       "/usr/local/bin/envoy",
 		ConfigPath:       "/etc/envoy",
 	}

--- a/proxy/envoy/testdata/envoy-fault.json.golden
+++ b/proxy/envoy/testdata/envoy-fault.json.golden
@@ -256,7 +256,7 @@
       "bind_to_port": false
     },
     {
-      "port": 5001,
+      "port": 15001,
       "filters": [],
       "bind_to_port": true,
       "use_original_dst": true
@@ -264,7 +264,7 @@
   ],
   "admin": {
     "access_log_path": "/dev/stdout",
-    "port": 5000
+    "port": 15000
   },
   "cluster_manager": {
     "clusters": [

--- a/proxy/envoy/testdata/envoy-v0.json.golden
+++ b/proxy/envoy/testdata/envoy-v0.json.golden
@@ -192,7 +192,7 @@
       "bind_to_port": false
     },
     {
-      "port": 5001,
+      "port": 15001,
       "filters": [],
       "bind_to_port": true,
       "use_original_dst": true
@@ -200,7 +200,7 @@
   ],
   "admin": {
     "access_log_path": "/dev/stdout",
-    "port": 5000
+    "port": 15000
   },
   "cluster_manager": {
     "clusters": [

--- a/proxy/envoy/testdata/envoy-v1.json.golden
+++ b/proxy/envoy/testdata/envoy-v1.json.golden
@@ -192,7 +192,7 @@
       "bind_to_port": false
     },
     {
-      "port": 5001,
+      "port": 15001,
       "filters": [],
       "bind_to_port": true,
       "use_original_dst": true
@@ -200,7 +200,7 @@
   ],
   "admin": {
     "access_log_path": "/dev/stdout",
-    "port": 5000
+    "port": 15000
   },
   "cluster_manager": {
     "clusters": [

--- a/test/integration/app-proxy-manager-agent.yaml.tmpl
+++ b/test/integration/app-proxy-manager-agent.yaml.tmpl
@@ -38,6 +38,7 @@ spec:
           [{
             "name": "iptables",
             "image": "{{.hub}}/init:{{.tag}}",
+            "args": ["-p", "15001", "-u", "1337"],
             "imagePullPolicy": "Always",
             "securityContext": { "capabilities" : { "add" : ["NET_ADMIN"] } }
           }]


### PR DESCRIPTION
- parametrize the script in preparation of using `configmap`s to store global configs
- change proxy port from 5001 to 15001 and admin port from 5000 to 15000 to prevent port collisions