### PR TITLE
Define secret registry

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -91,16 +91,10 @@ var (
 		Use:   "ingress",
 		Short: "Istio Proxy ingress controller",
 		RunE: func(c *cobra.Command, args []string) error {
-			setFlagsFromEnv()
 			controller := kube.NewController(cmd.Client, cmd.RootFlags.Namespace, resyncPeriod)
-			w, err := envoy.NewIngressWatcher(controller,
-				controller,
+			w, err := envoy.NewIngressWatcher(controller, controller,
 				&model.IstioRegistry{ConfigRegistry: controller},
-				cmd.Client.GetKubernetesClient(),
-				&flags.proxy,
-				&flags.identity,
-				flags.ingressSecret,
-				cmd.RootFlags.Namespace)
+				cmd.Client, &flags.proxy, flags.ingressSecret, cmd.RootFlags.Namespace)
 			if err != nil {
 				return err
 			}

--- a/model/BUILD
+++ b/model/BUILD
@@ -6,6 +6,7 @@ go_library(
         "config.go",
         "controller.go",
         "conversion.go",
+        "secret.go",
         "service.go",
         "validation.go",
     ],

--- a/model/secret.go
+++ b/model/secret.go
@@ -1,0 +1,24 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+// SecretRegistry defines a read-only interface for secret key material
+// The implementation should not cache or persist the secrets and pass
+// the data immediately to the client of this interface.
+// TODO: add controller hooks for notification about changes to the secret
+type SecretRegistry interface {
+	// GetSecret retrieves the secret data by a platform specific URI
+	GetSecret(uri string) (map[string][]byte, error)
+}

--- a/platform/kube/client.go
+++ b/platform/kube/client.go
@@ -353,6 +353,21 @@ func (cl *Client) List(kind, namespace string) (map[model.Key]proto.Message, err
 	return out, errs
 }
 
+// GetSecret implements secret registry operation: uri has the form "name.namespace"
+func (cl *Client) GetSecret(uri string) (map[string][]byte, error) {
+	dot := strings.Index(uri, ".")
+	if dot < 0 {
+		return nil, fmt.Errorf("Secret URI %q does not match 'name.namespace' pattern", uri)
+	}
+	name := uri[:dot]
+	namespace := uri[dot+1:]
+	secret, err := cl.client.Core().Secrets(namespace).Get(name, meta_v1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return secret.Data, nil
+}
+
 // configKey assigns k8s TPR name to Istio config
 func configKey(k *model.Key) string {
 	return k.Kind + "-" + k.Name

--- a/proxy/envoy/BUILD
+++ b/proxy/envoy/BUILD
@@ -23,8 +23,6 @@ go_library(
         "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_hashicorp_errwrap//:go_default_library",
         "@com_github_hashicorp_go_multierror//:go_default_library",
-        "@io_k8s_client_go//kubernetes:go_default_library",
-        "@io_k8s_client_go//pkg/apis/meta/v1:go_default_library",
     ],
 )
 

--- a/proxy/envoy/ingress.go
+++ b/proxy/envoy/ingress.go
@@ -199,7 +199,7 @@ const (
 func (w *ingressWatcher) buildSSLContext() (*SSLContext, error) {
 	var uri string
 	if w.namespace == "" {
-		uri = w.secret
+		uri = w.secret + ".default"
 	} else {
 		uri = fmt.Sprintf("%s.%s", w.secret, w.namespace)
 	}

--- a/proxy/envoy/ingress.go
+++ b/proxy/envoy/ingress.go
@@ -61,11 +61,19 @@ func NewIngressWatcher(discovery model.ServiceDiscovery, ctl model.Controller,
 		mesh:      mesh,
 	}
 
-	err := ctl.AppendConfigHandler(model.IngressRule,
-		func(model.Key, proto.Message, model.Event) { out.reload() })
-	if err != nil {
+	if err := ctl.AppendConfigHandler(model.IngressRule, func(model.Key, proto.Message, model.Event) {
+		out.reload()
+	}); err != nil {
 		return nil, err
 	}
+
+	// ingress rule listing depends on the service declaration being up to date
+	if err := ctl.AppendServiceHandler(func(*model.Service, model.Event) {
+		out.reload()
+	}); err != nil {
+		return nil, err
+	}
+
 	return out, nil
 }
 

--- a/test/integration/ingress-proxy.yaml.tmpl
+++ b/test/integration/ingress-proxy.yaml.tmpl
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   name: ingress
   labels:
-    infra: ingress
+    app: ingress
 spec:
   ports:
   - name: https
@@ -11,7 +11,7 @@ spec:
   - name: http
     port: 80
   selector:
-    infra: ingress
+    app: ingress
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -22,18 +22,13 @@ spec:
   template:
     metadata:
       labels:
-        infra: ingress
+        app: ingress
     spec:
       containers:
-      - name: ingress
+      - name: proxy
         image: {{.hub}}/runtime:{{.tag}}
         args: ["proxy", "ingress", "-s", "manager:8080", "-v", "2", "-n", "{{.namespace}}", "--secret", "ingress"]
         imagePullPolicy: Always
         ports:
         - containerPort: 443
         - containerPort: 80
-      - name: debug
-        image: docker.io/istio/debug:test
-        imagePullPolicy: Always
-        securityContext:
-            privileged: true


### PR DESCRIPTION
Basic interface to access secrets to prevent the use of k8s library directly in the proxy config gen.
Also, fixes a couple of bugs with ingress: default namespace and retries.