### PR TITLE
Keep ingress around

### DIFF
--- a/test/integration/driver.go
+++ b/test/integration/driver.go
@@ -103,6 +103,10 @@ func main() {
 		check((&reachability{}).run())
 		check(testRouting())
 	}
+
+	glog.Info("Cleaning up ingress secret.")
+	check(run("kubectl delete secret ingress -n " + params.namespace))
+
 	teardown()
 	glog.Infof("All tests passed %d time(s)!", params.count)
 }

--- a/test/integration/driver.go
+++ b/test/integration/driver.go
@@ -98,14 +98,12 @@ func init() {
 func main() {
 	flag.Parse()
 	setup()
+
 	for i := 0; i < params.count; i++ {
 		glog.Infof("Test run: %d", i)
 		check((&reachability{}).run())
 		check(testRouting())
 	}
-
-	glog.Info("Cleaning up ingress secret.")
-	check(run("kubectl delete secret ingress -n " + params.namespace))
 
 	teardown()
 	glog.Infof("All tests passed %d time(s)!", params.count)
@@ -182,6 +180,11 @@ func check(err error) {
 
 // teardown removes resources
 func teardown() {
+	glog.Info("Cleaning up ingress secret.")
+	if err := run("kubectl delete secret ingress -n " + params.namespace); err != nil {
+		glog.Warning(err)
+	}
+
 	if nameSpaceCreated {
 		deleteNamespace(client, params.namespace)
 		params.namespace = ""

--- a/test/integration/reachability.go
+++ b/test/integration/reachability.go
@@ -71,9 +71,6 @@ func (r *reachability) run() error {
 			return err
 		}
 	}
-	glog.Info("Cleaning up ingress secret.")
-	check(run("kubectl delete secret ingress -n " + params.namespace))
-
 	glog.Info("Success!")
 	return nil
 }


### PR DESCRIPTION
Fix a bug that was failing the post-submit. Ingress should be deleted once, not at every iteration.