### PR TITLE
Change service encoding scheme to satisfy Envoy

### DIFF
--- a/model/config_test.go
+++ b/model/config_test.go
@@ -617,7 +617,7 @@ func TestServiceKey(t *testing.T) {
 
 	// Verify Service.Key() delegates to ServiceKey()
 	{
-		want := "hostname:http:a=b,c=d"
+		want := "hostname|http|a=b,c=d"
 		port := &Port{Name: "http", Port: 80, Protocol: ProtocolHTTP}
 		tags := Tags{"a": "b", "c": "d"}
 		got := svc.Key(port, tags)
@@ -637,32 +637,32 @@ func TestServiceKey(t *testing.T) {
 				{Name: "http-alt", Port: 8080, Protocol: ProtocolHTTP},
 			},
 			tags: TagsList{{"a": "b", "c": "d"}},
-			want: "hostname:http,http-alt:a=b,c=d",
+			want: "hostname|http,http-alt|a=b,c=d",
 		},
 		{
 			port: PortList{{Name: "http", Port: 80, Protocol: ProtocolHTTP}},
 			tags: TagsList{{"a": "b", "c": "d"}},
-			want: "hostname:http:a=b,c=d",
+			want: "hostname|http|a=b,c=d",
 		},
 		{
 			port: PortList{{Port: 80, Protocol: ProtocolHTTP}},
 			tags: TagsList{{"a": "b", "c": "d"}},
-			want: "hostname::a=b,c=d",
+			want: "hostname||a=b,c=d",
 		},
 		{
 			port: PortList{},
 			tags: TagsList{{"a": "b", "c": "d"}},
-			want: "hostname::a=b,c=d",
+			want: "hostname||a=b,c=d",
 		},
 		{
 			port: PortList{{Name: "http", Port: 80, Protocol: ProtocolHTTP}},
 			tags: TagsList{nil},
-			want: "hostname:http",
+			want: "hostname|http",
 		},
 		{
 			port: PortList{{Name: "http", Port: 80, Protocol: ProtocolHTTP}},
 			tags: TagsList{},
-			want: "hostname:http",
+			want: "hostname|http",
 		},
 		{
 			port: PortList{},

--- a/model/service.go
+++ b/model/service.go
@@ -240,7 +240,9 @@ func (ports PortList) Get(name string) (*Port, bool) {
 	return nil, false
 }
 
-// Key generates a unique string referencing service instances for a given port and tags
+// Key generates a unique string referencing service instances for a given port and tags.
+// The separator character must be exclusive to the regular expressions allowed in the
+// service declaration.
 func (s *Service) Key(port *Port, tag Tags) string {
 	// TODO: check port is non nil and membership of port in service
 	return ServiceKey(s.Hostname, PortList{port}, TagsList{tag})
@@ -248,7 +250,7 @@ func (s *Service) Key(port *Port, tag Tags) string {
 
 // ServiceKey generates a service key for a collection of ports and tags
 func ServiceKey(hostname string, servicePorts PortList, serviceTags TagsList) string {
-	// example: name.namespace:http:env=prod;env=test,version=my-v1
+	// example: name.namespace|http|env=prod;env=test,version=my-v1
 	var buffer bytes.Buffer
 	buffer.WriteString(hostname)
 	np := len(servicePorts)
@@ -263,7 +265,7 @@ func ServiceKey(hostname string, servicePorts PortList, serviceTags TagsList) st
 	} else if np == 1 && nt == 0 && servicePorts[0].Name == "" {
 		return buffer.String()
 	} else {
-		buffer.WriteString(":")
+		buffer.WriteString("|")
 	}
 
 	if np > 0 {
@@ -281,7 +283,7 @@ func ServiceKey(hostname string, servicePorts PortList, serviceTags TagsList) st
 	}
 
 	if nt > 0 {
-		buffer.WriteString(":")
+		buffer.WriteString("|")
 		tags := make([]string, nt)
 		for i := 0; i < nt; i++ {
 			tags[i] = serviceTags[i].String()
@@ -299,7 +301,7 @@ func ServiceKey(hostname string, servicePorts PortList, serviceTags TagsList) st
 
 // ParseServiceKey is the inverse of the Service.String() method
 func ParseServiceKey(s string) (hostname string, ports PortList, tags TagsList) {
-	parts := strings.Split(s, ":")
+	parts := strings.Split(s, "|")
 	hostname = parts[0]
 
 	var names []string

--- a/model/service_test.go
+++ b/model/service_test.go
@@ -20,7 +20,7 @@ var validServiceKeys = map[string]struct {
 	service Service
 	tags    TagsList
 }{
-	"example-service1.default:grpc,http:a=b,c=d;e=f": {
+	"example-service1.default|grpc,http|a=b,c=d;e=f": {
 		service: Service{
 			Hostname: "example-service1.default",
 			Ports:    []*Port{{Name: "http"}, {Name: "grpc"}}},
@@ -33,17 +33,17 @@ var validServiceKeys = map[string]struct {
 		service: Service{
 			Hostname: "svc.ns",
 			Ports:    []*Port{{Name: ""}}}},
-	"svc::istio.io/my_tag-v1.test=my_value-v2.value": {
+	"svc||istio.io/my_tag-v1.test=my_value-v2.value": {
 		service: Service{
 			Hostname: "svc",
 			Ports:    []*Port{{Name: ""}}},
 		tags: TagsList{{"istio.io/my_tag-v1.test": "my_value-v2.value"}}},
-	"svc:test:prod": {
+	"svc|test|prod": {
 		service: Service{
 			Hostname: "svc",
 			Ports:    []*Port{{Name: "test"}}},
 		tags: TagsList{{"prod": ""}}},
-	"svc.default.svc.cluster.local:http-test": {
+	"svc.default.svc.cluster.local|http-test": {
 		service: Service{
 			Hostname: "svc.default.svc.cluster.local",
 			Ports:    []*Port{{Name: "http-test"}}}},

--- a/proxy/envoy/route.go
+++ b/proxy/envoy/route.go
@@ -31,10 +31,10 @@ import (
 
 const (
 	// InboundClusterPrefix is the prefix for service clusters co-hosted on the proxy instance
-	InboundClusterPrefix = "in:"
+	InboundClusterPrefix = "in."
 
 	// OutboundClusterPrefix is the prefix for service clusters external to the proxy instance
-	OutboundClusterPrefix = "out:"
+	OutboundClusterPrefix = "out."
 )
 
 func buildDefaultRoute(cluster *Cluster) *HTTPRoute {

--- a/proxy/envoy/testdata/cds-circuit-breaker.json.golden
+++ b/proxy/envoy/testdata/cds-circuit-breaker.json.golden
@@ -1,15 +1,15 @@
 {
   "clusters": [
    {
-    "name": "out:hello.default.svc.cluster.local:http-status",
-    "service_name": "hello.default.svc.cluster.local:http-status",
+    "name": "out.hello.default.svc.cluster.local|http-status",
+    "service_name": "hello.default.svc.cluster.local|http-status",
     "connect_timeout_ms": 1000,
     "type": "sds",
     "lb_type": "round_robin"
    },
    {
-    "name": "out:world.default.svc.cluster.local:custom",
-    "service_name": "world.default.svc.cluster.local:custom",
+    "name": "out.world.default.svc.cluster.local|custom",
+    "service_name": "world.default.svc.cluster.local|custom",
     "connect_timeout_ms": 1000,
     "type": "sds",
     "lb_type": "round_robin",
@@ -29,8 +29,8 @@
     }
    },
    {
-    "name": "out:world.default.svc.cluster.local:http",
-    "service_name": "world.default.svc.cluster.local:http",
+    "name": "out.world.default.svc.cluster.local|http",
+    "service_name": "world.default.svc.cluster.local|http",
     "connect_timeout_ms": 1000,
     "type": "sds",
     "lb_type": "round_robin",
@@ -50,8 +50,8 @@
     }
    },
    {
-    "name": "out:world.default.svc.cluster.local:http-status",
-    "service_name": "world.default.svc.cluster.local:http-status",
+    "name": "out.world.default.svc.cluster.local|http-status",
+    "service_name": "world.default.svc.cluster.local|http-status",
     "connect_timeout_ms": 1000,
     "type": "sds",
     "lb_type": "round_robin",

--- a/proxy/envoy/testdata/cds-ssl-context.json.golden
+++ b/proxy/envoy/testdata/cds-ssl-context.json.golden
@@ -1,8 +1,8 @@
 {
   "clusters": [
    {
-    "name": "out:hello.default.svc.cluster.local:http-status",
-    "service_name": "hello.default.svc.cluster.local:http-status",
+    "name": "out.hello.default.svc.cluster.local|http-status",
+    "service_name": "hello.default.svc.cluster.local|http-status",
     "connect_timeout_ms": 1000,
     "type": "sds",
     "lb_type": "round_robin",
@@ -14,15 +14,15 @@
     }
    },
    {
-    "name": "out:world.default.svc.cluster.local:custom",
-    "service_name": "world.default.svc.cluster.local:custom",
+    "name": "out.world.default.svc.cluster.local|custom",
+    "service_name": "world.default.svc.cluster.local|custom",
     "connect_timeout_ms": 1000,
     "type": "sds",
     "lb_type": "round_robin"
    },
    {
-    "name": "out:world.default.svc.cluster.local:http",
-    "service_name": "world.default.svc.cluster.local:http",
+    "name": "out.world.default.svc.cluster.local|http",
+    "service_name": "world.default.svc.cluster.local|http",
     "connect_timeout_ms": 1000,
     "type": "sds",
     "lb_type": "round_robin",
@@ -37,8 +37,8 @@
     }
    },
    {
-    "name": "out:world.default.svc.cluster.local:http-status",
-    "service_name": "world.default.svc.cluster.local:http-status",
+    "name": "out.world.default.svc.cluster.local|http-status",
+    "service_name": "world.default.svc.cluster.local|http-status",
     "connect_timeout_ms": 1000,
     "type": "sds",
     "lb_type": "round_robin",

--- a/proxy/envoy/testdata/cds.json.golden
+++ b/proxy/envoy/testdata/cds.json.golden
@@ -1,29 +1,29 @@
 {
   "clusters": [
    {
-    "name": "out:hello.default.svc.cluster.local:http-status",
-    "service_name": "hello.default.svc.cluster.local:http-status",
+    "name": "out.hello.default.svc.cluster.local|http-status",
+    "service_name": "hello.default.svc.cluster.local|http-status",
     "connect_timeout_ms": 1000,
     "type": "sds",
     "lb_type": "round_robin"
    },
    {
-    "name": "out:world.default.svc.cluster.local:custom",
-    "service_name": "world.default.svc.cluster.local:custom",
+    "name": "out.world.default.svc.cluster.local|custom",
+    "service_name": "world.default.svc.cluster.local|custom",
     "connect_timeout_ms": 1000,
     "type": "sds",
     "lb_type": "round_robin"
    },
    {
-    "name": "out:world.default.svc.cluster.local:http",
-    "service_name": "world.default.svc.cluster.local:http",
+    "name": "out.world.default.svc.cluster.local|http",
+    "service_name": "world.default.svc.cluster.local|http",
     "connect_timeout_ms": 1000,
     "type": "sds",
     "lb_type": "round_robin"
    },
    {
-    "name": "out:world.default.svc.cluster.local:http-status",
-    "service_name": "world.default.svc.cluster.local:http-status",
+    "name": "out.world.default.svc.cluster.local|http-status",
+    "service_name": "world.default.svc.cluster.local|http-status",
     "connect_timeout_ms": 1000,
     "type": "sds",
     "lb_type": "round_robin"

--- a/proxy/envoy/testdata/envoy-fault.json.golden
+++ b/proxy/envoy/testdata/envoy-fault.json.golden
@@ -57,7 +57,7 @@
             "route_config": {
               "routes": [
                 {
-                  "cluster": "in:1090",
+                  "cluster": "in.1090",
                   "destination_ip_list": [
                     "10.1.1.0/32"
                   ]
@@ -128,7 +128,7 @@
                       "value": "doo"
                     }
                   ],
-                  "upstream_cluster": "out:world.default.svc.cluster.local:http:version=v1"
+                  "upstream_cluster": "out.world.default.svc.cluster.local|http|version=v1"
                 }
               },
               {
@@ -206,7 +206,7 @@
                       "value": "doo"
                     }
                   ],
-                  "upstream_cluster": "out:world.default.svc.cluster.local:http-status:version=v1"
+                  "upstream_cluster": "out.world.default.svc.cluster.local|http-status|version=v1"
                 }
               },
               {
@@ -236,13 +236,13 @@
             "route_config": {
               "routes": [
                 {
-                  "cluster": "in:1090",
+                  "cluster": "in.1090",
                   "destination_ip_list": [
                     "10.1.0.0/32"
                   ]
                 },
                 {
-                  "cluster": "out:world.default.svc.cluster.local:custom",
+                  "cluster": "out.world.default.svc.cluster.local|custom",
                   "destination_ip_list": [
                     "10.2.0.0/32"
                   ],
@@ -269,7 +269,7 @@
   "cluster_manager": {
     "clusters": [
       {
-        "name": "in:1081",
+        "name": "in.1081",
         "connect_timeout_ms": 1000,
         "type": "static",
         "lb_type": "round_robin",
@@ -280,7 +280,7 @@
         ]
       },
       {
-        "name": "in:1090",
+        "name": "in.1090",
         "connect_timeout_ms": 1000,
         "type": "static",
         "lb_type": "round_robin",
@@ -291,7 +291,7 @@
         ]
       },
       {
-        "name": "in:80",
+        "name": "in.80",
         "connect_timeout_ms": 1000,
         "type": "static",
         "lb_type": "round_robin",
@@ -302,8 +302,8 @@
         ]
       },
       {
-        "name": "out:world.default.svc.cluster.local:custom",
-        "service_name": "world.default.svc.cluster.local:custom",
+        "name": "out.world.default.svc.cluster.local|custom",
+        "service_name": "world.default.svc.cluster.local|custom",
         "connect_timeout_ms": 1000,
         "type": "sds",
         "lb_type": "round_robin"

--- a/proxy/envoy/testdata/envoy-v0.json.golden
+++ b/proxy/envoy/testdata/envoy-v0.json.golden
@@ -57,7 +57,7 @@
             "route_config": {
               "routes": [
                 {
-                  "cluster": "in:1090",
+                  "cluster": "in.1090",
                   "destination_ip_list": [
                     "10.1.1.0/32"
                   ]
@@ -172,13 +172,13 @@
             "route_config": {
               "routes": [
                 {
-                  "cluster": "in:1090",
+                  "cluster": "in.1090",
                   "destination_ip_list": [
                     "10.1.0.0/32"
                   ]
                 },
                 {
-                  "cluster": "out:world.default.svc.cluster.local:custom",
+                  "cluster": "out.world.default.svc.cluster.local|custom",
                   "destination_ip_list": [
                     "10.2.0.0/32"
                   ],
@@ -205,7 +205,7 @@
   "cluster_manager": {
     "clusters": [
       {
-        "name": "in:1081",
+        "name": "in.1081",
         "connect_timeout_ms": 1000,
         "type": "static",
         "lb_type": "round_robin",
@@ -216,7 +216,7 @@
         ]
       },
       {
-        "name": "in:1090",
+        "name": "in.1090",
         "connect_timeout_ms": 1000,
         "type": "static",
         "lb_type": "round_robin",
@@ -227,7 +227,7 @@
         ]
       },
       {
-        "name": "in:80",
+        "name": "in.80",
         "connect_timeout_ms": 1000,
         "type": "static",
         "lb_type": "round_robin",
@@ -238,8 +238,8 @@
         ]
       },
       {
-        "name": "out:world.default.svc.cluster.local:custom",
-        "service_name": "world.default.svc.cluster.local:custom",
+        "name": "out.world.default.svc.cluster.local|custom",
+        "service_name": "world.default.svc.cluster.local|custom",
         "connect_timeout_ms": 1000,
         "type": "sds",
         "lb_type": "round_robin"

--- a/proxy/envoy/testdata/envoy-v1.json.golden
+++ b/proxy/envoy/testdata/envoy-v1.json.golden
@@ -57,7 +57,7 @@
             "route_config": {
               "routes": [
                 {
-                  "cluster": "in:1090",
+                  "cluster": "in.1090",
                   "destination_ip_list": [
                     "10.1.1.1/32"
                   ]
@@ -172,13 +172,13 @@
             "route_config": {
               "routes": [
                 {
-                  "cluster": "in:1090",
+                  "cluster": "in.1090",
                   "destination_ip_list": [
                     "10.1.0.0/32"
                   ]
                 },
                 {
-                  "cluster": "out:world.default.svc.cluster.local:custom",
+                  "cluster": "out.world.default.svc.cluster.local|custom",
                   "destination_ip_list": [
                     "10.2.0.0/32"
                   ],
@@ -205,7 +205,7 @@
   "cluster_manager": {
     "clusters": [
       {
-        "name": "in:1081",
+        "name": "in.1081",
         "connect_timeout_ms": 1000,
         "type": "static",
         "lb_type": "round_robin",
@@ -216,7 +216,7 @@
         ]
       },
       {
-        "name": "in:1090",
+        "name": "in.1090",
         "connect_timeout_ms": 1000,
         "type": "static",
         "lb_type": "round_robin",
@@ -227,7 +227,7 @@
         ]
       },
       {
-        "name": "in:80",
+        "name": "in.80",
         "connect_timeout_ms": 1000,
         "type": "static",
         "lb_type": "round_robin",
@@ -238,8 +238,8 @@
         ]
       },
       {
-        "name": "out:world.default.svc.cluster.local:custom",
-        "service_name": "world.default.svc.cluster.local:custom",
+        "name": "out.world.default.svc.cluster.local|custom",
+        "service_name": "world.default.svc.cluster.local|custom",
         "connect_timeout_ms": 1000,
         "type": "sds",
         "lb_type": "round_robin"

--- a/proxy/envoy/testdata/rds-fault.json.golden
+++ b/proxy/envoy/testdata/rds-fault.json.golden
@@ -1,7 +1,7 @@
 {
   "virtual_hosts": [
    {
-    "name": "hello.default.svc.cluster.local:http",
+    "name": "hello.default.svc.cluster.local|http",
     "domains": [
      "hello:80",
      "hello",
@@ -21,7 +21,7 @@
     "routes": [
      {
       "prefix": "/",
-      "cluster": "in:80",
+      "cluster": "in.80",
       "opaque_config": {
        "mixer_control": "on",
        "mixer_forward": "off"
@@ -30,7 +30,7 @@
     ]
    },
    {
-    "name": "world.default.svc.cluster.local:http",
+    "name": "world.default.svc.cluster.local|http",
     "domains": [
      "world:80",
      "world",
@@ -48,7 +48,7 @@
     "routes": [
      {
       "prefix": "/",
-      "cluster": "out:world.default.svc.cluster.local:http:version=v1",
+      "cluster": "out.world.default.svc.cluster.local|http|version=v1",
       "headers": [
        {
         "name": "animal",
@@ -68,7 +68,7 @@
      },
      {
       "prefix": "/",
-      "cluster": "out:world.default.svc.cluster.local:http"
+      "cluster": "out.world.default.svc.cluster.local|http"
      }
     ]
    }

--- a/proxy/envoy/testdata/rds-timeout.json.golden
+++ b/proxy/envoy/testdata/rds-timeout.json.golden
@@ -1,7 +1,7 @@
 {
   "virtual_hosts": [
    {
-    "name": "hello.default.svc.cluster.local:http",
+    "name": "hello.default.svc.cluster.local|http",
     "domains": [
      "hello:80",
      "hello",
@@ -21,7 +21,7 @@
     "routes": [
      {
       "prefix": "/",
-      "cluster": "in:80",
+      "cluster": "in.80",
       "opaque_config": {
        "mixer_control": "on",
        "mixer_forward": "off"
@@ -30,7 +30,7 @@
     ]
    },
    {
-    "name": "world.default.svc.cluster.local:http",
+    "name": "world.default.svc.cluster.local|http",
     "domains": [
      "world:80",
      "world",
@@ -48,7 +48,7 @@
     "routes": [
      {
       "prefix": "/",
-      "cluster": "out:world.default.svc.cluster.local:http",
+      "cluster": "out.world.default.svc.cluster.local|http",
       "timeout_ms": 30000,
       "retry_policy": {
        "retry_on": "5xx,connect-failure,refused-stream",

--- a/proxy/envoy/testdata/rds-v0.json.golden
+++ b/proxy/envoy/testdata/rds-v0.json.golden
@@ -1,7 +1,7 @@
 {
   "virtual_hosts": [
    {
-    "name": "hello.default.svc.cluster.local:http",
+    "name": "hello.default.svc.cluster.local|http",
     "domains": [
      "hello:80",
      "hello",
@@ -21,7 +21,7 @@
     "routes": [
      {
       "prefix": "/",
-      "cluster": "in:80",
+      "cluster": "in.80",
       "opaque_config": {
        "mixer_control": "on",
        "mixer_forward": "off"
@@ -30,7 +30,7 @@
     ]
    },
    {
-    "name": "world.default.svc.cluster.local:http",
+    "name": "world.default.svc.cluster.local|http",
     "domains": [
      "world:80",
      "world",
@@ -48,7 +48,7 @@
     "routes": [
      {
       "prefix": "/",
-      "cluster": "out:world.default.svc.cluster.local:http"
+      "cluster": "out.world.default.svc.cluster.local|http"
      }
     ]
    }

--- a/proxy/envoy/testdata/rds-v1.json.golden
+++ b/proxy/envoy/testdata/rds-v1.json.golden
@@ -1,7 +1,7 @@
 {
   "virtual_hosts": [
    {
-    "name": "hello.default.svc.cluster.local:http",
+    "name": "hello.default.svc.cluster.local|http",
     "domains": [
      "hello:80",
      "hello",
@@ -21,7 +21,7 @@
     "routes": [
      {
       "prefix": "/",
-      "cluster": "in:80",
+      "cluster": "in.80",
       "opaque_config": {
        "mixer_control": "on",
        "mixer_forward": "off"
@@ -30,7 +30,7 @@
     ]
    },
    {
-    "name": "world.default.svc.cluster.local:http",
+    "name": "world.default.svc.cluster.local|http",
     "domains": [
      "world:80",
      "world",
@@ -48,7 +48,7 @@
     "routes": [
      {
       "prefix": "/",
-      "cluster": "out:world.default.svc.cluster.local:http"
+      "cluster": "out.world.default.svc.cluster.local|http"
      }
     ]
    }

--- a/proxy/envoy/testdata/rds-weighted.json.golden
+++ b/proxy/envoy/testdata/rds-weighted.json.golden
@@ -1,7 +1,7 @@
 {
   "virtual_hosts": [
    {
-    "name": "hello.default.svc.cluster.local:http",
+    "name": "hello.default.svc.cluster.local|http",
     "domains": [
      "hello:80",
      "hello",
@@ -21,7 +21,7 @@
     "routes": [
      {
       "prefix": "/",
-      "cluster": "in:80",
+      "cluster": "in.80",
       "opaque_config": {
        "mixer_control": "on",
        "mixer_forward": "off"
@@ -30,7 +30,7 @@
     ]
    },
    {
-    "name": "world.default.svc.cluster.local:http",
+    "name": "world.default.svc.cluster.local|http",
     "domains": [
      "world:80",
      "world",
@@ -52,11 +52,11 @@
       "weighted_clusters": {
        "clusters": [
         {
-         "name": "out:world.default.svc.cluster.local:http:version=v0",
+         "name": "out.world.default.svc.cluster.local|http|version=v0",
          "weight": 75
         },
         {
-         "name": "out:world.default.svc.cluster.local:http:version=v1",
+         "name": "out.world.default.svc.cluster.local|http|version=v1",
          "weight": 25
         }
        ]


### PR DESCRIPTION
Envoy is enforcing schema on cluster names and that means ":" is no longer allowed.