### PR TITLE
Use IP address in the listeners

### DIFF
--- a/proxy/envoy/config_test.go
+++ b/proxy/envoy/config_test.go
@@ -82,12 +82,12 @@ func TestRoutesByPath(t *testing.T) {
 func TestTCPRouteConfigByRoute(t *testing.T) {
 	cases := []struct {
 		name string
-		in   []TCPRoute
-		want []TCPRoute
+		in   []*TCPRoute
+		want []*TCPRoute
 	}{
 		{
 			name: "sorted by cluster",
-			in: []TCPRoute{{
+			in: []*TCPRoute{{
 				Cluster:           "cluster-b",
 				DestinationIPList: []string{"192.168.1.1/32", "192.168.1.2/32"},
 				DestinationPorts:  "5000",
@@ -96,7 +96,7 @@ func TestTCPRouteConfigByRoute(t *testing.T) {
 				DestinationIPList: []string{"192.168.1.2/32", "192.168.1.1/32"},
 				DestinationPorts:  "5000",
 			}},
-			want: []TCPRoute{{
+			want: []*TCPRoute{{
 				Cluster:           "cluster-a",
 				DestinationIPList: []string{"192.168.1.2/32", "192.168.1.1/32"},
 				DestinationPorts:  "5000",
@@ -108,7 +108,7 @@ func TestTCPRouteConfigByRoute(t *testing.T) {
 		},
 		{
 			name: "sorted by DestinationIPList",
-			in: []TCPRoute{{
+			in: []*TCPRoute{{
 				Cluster:           "cluster-a",
 				DestinationIPList: []string{"192.168.2.1/32", "192.168.2.2/32"},
 				DestinationPorts:  "5000",
@@ -117,7 +117,7 @@ func TestTCPRouteConfigByRoute(t *testing.T) {
 				DestinationIPList: []string{"192.168.1.1/32", "192.168.1.2/32"},
 				DestinationPorts:  "5000",
 			}},
-			want: []TCPRoute{{
+			want: []*TCPRoute{{
 				Cluster:           "cluster-a",
 				DestinationIPList: []string{"192.168.1.1/32", "192.168.1.2/32"},
 				DestinationPorts:  "5000",
@@ -129,7 +129,7 @@ func TestTCPRouteConfigByRoute(t *testing.T) {
 		},
 		{
 			name: "sorted by DestinationPorts",
-			in: []TCPRoute{{
+			in: []*TCPRoute{{
 				Cluster:           "cluster-a",
 				DestinationIPList: []string{"192.168.1.1/32", "192.168.1.2/32"},
 				DestinationPorts:  "5001",
@@ -138,7 +138,7 @@ func TestTCPRouteConfigByRoute(t *testing.T) {
 				DestinationIPList: []string{"192.168.1.1/32", "192.168.1.2/32"},
 				DestinationPorts:  "5000",
 			}},
-			want: []TCPRoute{{
+			want: []*TCPRoute{{
 				Cluster:           "cluster-a",
 				DestinationIPList: []string{"192.168.1.1/32", "192.168.1.2/32"},
 				DestinationPorts:  "5000",
@@ -150,7 +150,7 @@ func TestTCPRouteConfigByRoute(t *testing.T) {
 		},
 		{
 			name: "sorted by SourceIPList",
-			in: []TCPRoute{{
+			in: []*TCPRoute{{
 				Cluster:           "cluster-a",
 				DestinationIPList: []string{"192.168.1.1/32", "192.168.1.2/32"},
 				DestinationPorts:  "5000",
@@ -163,7 +163,7 @@ func TestTCPRouteConfigByRoute(t *testing.T) {
 				SourceIPList:      []string{"192.168.2.1/32", "192.168.2.2/32"},
 				SourcePorts:       "5002",
 			}},
-			want: []TCPRoute{{
+			want: []*TCPRoute{{
 				Cluster:           "cluster-a",
 				DestinationIPList: []string{"192.168.1.1/32", "192.168.1.2/32"},
 				DestinationPorts:  "5000",
@@ -179,7 +179,7 @@ func TestTCPRouteConfigByRoute(t *testing.T) {
 		},
 		{
 			name: "sorted by SourcePorts",
-			in: []TCPRoute{{
+			in: []*TCPRoute{{
 				Cluster:           "cluster-a",
 				DestinationIPList: []string{"192.168.1.1/32", "192.168.1.2/32"},
 				DestinationPorts:  "5000",
@@ -192,7 +192,7 @@ func TestTCPRouteConfigByRoute(t *testing.T) {
 				SourceIPList:      []string{"192.168.2.1/32", "192.168.2.2/32"},
 				SourcePorts:       "5002",
 			}},
-			want: []TCPRoute{{
+			want: []*TCPRoute{{
 				Cluster:           "cluster-a",
 				DestinationIPList: []string{"192.168.1.1/32", "192.168.1.2/32"},
 				DestinationPorts:  "5000",

--- a/proxy/envoy/discovery.go
+++ b/proxy/envoy/discovery.go
@@ -148,7 +148,7 @@ func (ds *DiscoveryService) ListClusters(request *restful.Request, response *res
 	})
 
 	// de-duplicate and canonicalize clusters
-	clusters := httpRouteConfigs.clusters().Normalize()
+	clusters := httpRouteConfigs.clusters().normalize()
 
 	for _, cluster := range clusters {
 		insertDestinationPolicy(ds.config, cluster)

--- a/proxy/envoy/discovery.go
+++ b/proxy/envoy/discovery.go
@@ -140,7 +140,7 @@ func (ds *DiscoveryService) ListClusters(request *restful.Request, response *res
 	addrs := map[string]bool{ip: true}
 	instances := ds.services.HostInstances(addrs)
 	services := ds.services.Services()
-	httpRouteConfigs, _ := buildOutboundRoutes(instances, services, &ProxyContext{
+	httpRouteConfigs := buildOutboundHTTPRoutes(instances, services, &ProxyContext{
 		Discovery:  ds.services,
 		Config:     ds.config,
 		MeshConfig: ds.mesh,
@@ -150,6 +150,7 @@ func (ds *DiscoveryService) ListClusters(request *restful.Request, response *res
 	// de-duplicate and canonicalize clusters
 	clusters := httpRouteConfigs.clusters().normalize()
 
+	// apply custom policies for HTTP clusters
 	for _, cluster := range clusters {
 		insertDestinationPolicy(ds.config, cluster)
 	}
@@ -182,7 +183,7 @@ func (ds *DiscoveryService) ListRoutes(request *restful.Request, response *restf
 	addrs := map[string]bool{ip: true}
 	instances := ds.services.HostInstances(addrs)
 	services := ds.services.Services()
-	httpRouteConfigs, _ := buildOutboundRoutes(instances, services, &ProxyContext{
+	httpRouteConfigs := buildOutboundHTTPRoutes(instances, services, &ProxyContext{
 		Discovery:  ds.services,
 		Config:     ds.config,
 		MeshConfig: ds.mesh,

--- a/proxy/envoy/discovery.go
+++ b/proxy/envoy/discovery.go
@@ -137,27 +137,18 @@ func (ds *DiscoveryService) ListClusters(request *restful.Request, response *res
 	// TODO: this implementation is inefficient as it is recomputing all the routes for all proxies
 	// There is a lot of potential to cache and reuse cluster definitions across proxies and also
 	// skip computing the actual HTTP routes
-	httpRouteConfigs, tcpRouteConfigs := buildRoutes(&ProxyContext{
+	addrs := map[string]bool{ip: true}
+	instances := ds.services.HostInstances(addrs)
+	services := ds.services.Services()
+	httpRouteConfigs, _ := buildOutboundRoutes(instances, services, &ProxyContext{
 		Discovery:  ds.services,
 		Config:     ds.config,
 		MeshConfig: ds.mesh,
-		Addrs:      map[string]bool{ip: true},
+		Addrs:      addrs,
 	})
 
-	clusters := make(Clusters, 0)
-	for _, httpRouteConfig := range httpRouteConfigs {
-		clusters = append(clusters, httpRouteConfig.filterClusters(func(cluster *Cluster) bool {
-			return cluster.outbound
-		})...)
-	}
-	for _, tcpRouteConfig := range tcpRouteConfigs {
-		clusters = append(clusters, tcpRouteConfig.filterClusters(func(cluster *Cluster) bool {
-			return cluster.outbound
-		})...)
-	}
-
 	// de-duplicate and canonicalize clusters
-	clusters = clusters.Normalize()
+	clusters := httpRouteConfigs.clusters().Normalize()
 
 	for _, cluster := range clusters {
 		insertDestinationPolicy(ds.config, cluster)
@@ -188,11 +179,14 @@ func (ds *DiscoveryService) ListRoutes(request *restful.Request, response *restf
 		return
 	}
 
-	httpRouteConfigs, _ := buildRoutes(&ProxyContext{
+	addrs := map[string]bool{ip: true}
+	instances := ds.services.HostInstances(addrs)
+	services := ds.services.Services()
+	httpRouteConfigs, _ := buildOutboundRoutes(instances, services, &ProxyContext{
 		Discovery:  ds.services,
 		Config:     ds.config,
 		MeshConfig: ds.mesh,
-		Addrs:      map[string]bool{ip: true},
+		Addrs:      addrs,
 	})
 
 	routeConfig, ok := httpRouteConfigs[port]

--- a/proxy/envoy/ingress.go
+++ b/proxy/envoy/ingress.go
@@ -171,7 +171,7 @@ func (w *ingressWatcher) generateConfig() *Config {
 	}
 
 	listeners := []*Listener{listener}
-	clusters := Clusters(rConfig.filterClusters(func(cl *Cluster) bool { return true })).Normalize()
+	clusters := rConfig.clusters().Normalize()
 
 	return &Config{
 		Listeners: listeners,

--- a/proxy/envoy/ingress.go
+++ b/proxy/envoy/ingress.go
@@ -171,7 +171,7 @@ func (w *ingressWatcher) generateConfig() *Config {
 	}
 
 	listeners := []*Listener{listener}
-	clusters := rConfig.clusters().Normalize()
+	clusters := rConfig.clusters().normalize()
 
 	return &Config{
 		Listeners: listeners,

--- a/proxy/envoy/policy.go
+++ b/proxy/envoy/policy.go
@@ -25,7 +25,7 @@ import (
 	proxyconfig "istio.io/manager/model/proxy/alphav1/config"
 )
 
-func insertMixerFilter(listeners []*Listener, context *ProxyContext) {
+func insertMixerFilter(listeners []*Listener, instances []*model.ServiceInstance, context *ProxyContext) {
 	if context.MeshConfig.MixerAddress == "" {
 		return
 	}
@@ -39,7 +39,6 @@ func insertMixerFilter(listeners []*Listener, context *ProxyContext) {
 	id := strings.Join(ips, ",")
 
 	// join service names with a comma
-	instances := context.Discovery.HostInstances(context.Addrs)
 	serviceSet := make(map[string]bool)
 	for _, instance := range instances {
 		serviceSet[instance.Service.Hostname] = true

--- a/proxy/envoy/resources.go
+++ b/proxy/envoy/resources.go
@@ -376,14 +376,6 @@ type TCPRouteConfig struct {
 	Routes []*TCPRoute `json:"routes"`
 }
 
-func (rc *TCPRouteConfig) clusters() Clusters {
-	out := make(Clusters, 0)
-	for _, route := range rc.Routes {
-		out = append(out, route.clusterRef)
-	}
-	return out
-}
-
 // NetworkFilter definition
 type NetworkFilter struct {
 	Type   string      `json:"type"`

--- a/proxy/envoy/resources.go
+++ b/proxy/envoy/resources.go
@@ -97,6 +97,9 @@ const (
 
 	// URI HTTP header
 	HeaderURI = "uri"
+
+	// WildcardAddress binds to all IP addresses
+	WildcardAddress = "0.0.0.0"
 )
 
 // Config defines the schema for Envoy JSON configuration format
@@ -406,6 +409,12 @@ type Listener struct {
 // Listeners is a collection of listeners
 type Listeners []*Listener
 
+// normalize outputs the canonical form (modifies the slice)
+func (listeners Listeners) normalize() Listeners {
+	sort.Slice(listeners, func(i, j int) bool { return listeners[i].Address < listeners[j].Address })
+	return listeners
+}
+
 // SSLContext definition
 type SSLContext struct {
 	CertChainFile  string `json:"cert_chain_file"`
@@ -478,20 +487,8 @@ type OutlierDetection struct {
 // Clusters is a collection of clusters
 type Clusters []*Cluster
 
-func (s Clusters) Len() int {
-	return len(s)
-}
-
-func (s Clusters) Swap(i, j int) {
-	s[i], s[j] = s[j], s[i]
-}
-
-func (s Clusters) Less(i, j int) bool {
-	return s[i].Name < s[j].Name
-}
-
-// Normalize deduplicates and sorts clusters
-func (s Clusters) Normalize() Clusters {
+// normalize deduplicates and sorts clusters
+func (s Clusters) normalize() Clusters {
 	out := make(Clusters, 0)
 	set := make(map[string]bool)
 	for _, cluster := range s {
@@ -500,7 +497,7 @@ func (s Clusters) Normalize() Clusters {
 			out = append(out, cluster)
 		}
 	}
-	sort.Sort(out)
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
 	return out
 }
 

--- a/proxy/envoy/route.go
+++ b/proxy/envoy/route.go
@@ -20,7 +20,6 @@ package envoy
 import (
 	"fmt"
 	"sort"
-	"strconv"
 	"strings"
 
 	"github.com/golang/glog"
@@ -297,13 +296,12 @@ func sharedHost(parts ...[]string) []string {
 	}
 }
 
-func buildTCPRoute(cluster *Cluster, addresses []string, port int) *TCPRoute {
+func buildTCPRoute(cluster *Cluster, addresses []string) *TCPRoute {
+	// destination port is unnecessary with use_original_dst since
+	// the listener address already contains the port
 	route := &TCPRoute{
 		Cluster:    cluster.Name,
 		clusterRef: cluster,
-	}
-	if port >= 0 {
-		route.DestinationPorts = strconv.Itoa(port)
 	}
 	sort.Sort(sort.StringSlice(addresses))
 	for _, addr := range addresses {

--- a/proxy/envoy/testdata/cds-circuit-breaker.json.golden
+++ b/proxy/envoy/testdata/cds-circuit-breaker.json.golden
@@ -1,32 +1,18 @@
 {
   "clusters": [
    {
-    "name": "out.hello.default.svc.cluster.local|http-status",
-    "service_name": "hello.default.svc.cluster.local|http-status",
+    "name": "out.hello.default.svc.cluster.local|http",
+    "service_name": "hello.default.svc.cluster.local|http",
     "connect_timeout_ms": 1000,
     "type": "sds",
     "lb_type": "round_robin"
    },
    {
-    "name": "out.world.default.svc.cluster.local|custom",
-    "service_name": "world.default.svc.cluster.local|custom",
+    "name": "out.hello.default.svc.cluster.local|http-status",
+    "service_name": "hello.default.svc.cluster.local|http-status",
     "connect_timeout_ms": 1000,
     "type": "sds",
-    "lb_type": "round_robin",
-    "max_requests_per_connection": 100,
-    "circuit_breakers": {
-     "default": {
-      "max_connections": 100,
-      "max_pending_requests": 100,
-      "max_requests": 100
-     }
-    },
-    "outlier_detection": {
-     "consecutive_5xx": 10,
-     "interval_ms": 30000,
-     "base_ejection_time_ms": 15500,
-     "max_ejection_percent": 100
-    }
+    "lb_type": "round_robin"
    },
    {
     "name": "out.world.default.svc.cluster.local|http",

--- a/proxy/envoy/testdata/cds-ssl-context.json.golden
+++ b/proxy/envoy/testdata/cds-ssl-context.json.golden
@@ -1,8 +1,8 @@
 {
   "clusters": [
    {
-    "name": "out.hello.default.svc.cluster.local|http-status",
-    "service_name": "hello.default.svc.cluster.local|http-status",
+    "name": "out.hello.default.svc.cluster.local|http",
+    "service_name": "hello.default.svc.cluster.local|http",
     "connect_timeout_ms": 1000,
     "type": "sds",
     "lb_type": "round_robin",
@@ -14,11 +14,17 @@
     }
    },
    {
-    "name": "out.world.default.svc.cluster.local|custom",
-    "service_name": "world.default.svc.cluster.local|custom",
+    "name": "out.hello.default.svc.cluster.local|http-status",
+    "service_name": "hello.default.svc.cluster.local|http-status",
     "connect_timeout_ms": 1000,
     "type": "sds",
-    "lb_type": "round_robin"
+    "lb_type": "round_robin",
+    "ssl_context": {
+     "cert_chain_file": "/etc/certs/cert-chain.pem",
+     "private_key_file": "/etc/certs/key.pem",
+     "ca_cert_file": "/etc/certs/root-cert.pem",
+     "verify_subject_alt_name": []
+    }
    },
    {
     "name": "out.world.default.svc.cluster.local|http",

--- a/proxy/envoy/testdata/cds.json.golden
+++ b/proxy/envoy/testdata/cds.json.golden
@@ -1,15 +1,15 @@
 {
   "clusters": [
    {
-    "name": "out.hello.default.svc.cluster.local|http-status",
-    "service_name": "hello.default.svc.cluster.local|http-status",
+    "name": "out.hello.default.svc.cluster.local|http",
+    "service_name": "hello.default.svc.cluster.local|http",
     "connect_timeout_ms": 1000,
     "type": "sds",
     "lb_type": "round_robin"
    },
    {
-    "name": "out.world.default.svc.cluster.local|custom",
-    "service_name": "world.default.svc.cluster.local|custom",
+    "name": "out.hello.default.svc.cluster.local|http-status",
+    "service_name": "hello.default.svc.cluster.local|http-status",
     "connect_timeout_ms": 1000,
     "type": "sds",
     "lb_type": "round_robin"

--- a/proxy/envoy/testdata/envoy-fault.json.golden
+++ b/proxy/envoy/testdata/envoy-fault.json.golden
@@ -1,75 +1,6 @@
 {
   "listeners": [
     {
-      "address": "tcp://0.0.0.0:1081",
-      "filters": [
-        {
-          "type": "read",
-          "name": "http_connection_manager",
-          "config": {
-            "codec_type": "auto",
-            "stat_prefix": "http",
-            "rds": {
-              "cluster": "rds",
-              "route_config_name": "1081",
-              "refresh_delay_ms": 1000
-            },
-            "filters": [
-              {
-                "type": "decoder",
-                "name": "mixer",
-                "config": {
-                  "mixer_server": "mixer:9091",
-                  "mixer_attributes": {
-                    "target.service": "hello.default.svc.cluster.local",
-                    "target.uid": "10.1.1.0"
-                  },
-                  "forward_attributes": {
-                    "source.service": "hello.default.svc.cluster.local",
-                    "source.uid": "10.1.1.0"
-                  }
-                }
-              },
-              {
-                "type": "decoder",
-                "name": "router",
-                "config": {}
-              }
-            ],
-            "access_log": [
-              {
-                "path": "/dev/stdout"
-              }
-            ]
-          }
-        }
-      ],
-      "bind_to_port": false
-    },
-    {
-      "address": "tcp://0.0.0.0:1090",
-      "filters": [
-        {
-          "type": "read",
-          "name": "tcp_proxy",
-          "config": {
-            "stat_prefix": "tcp",
-            "route_config": {
-              "routes": [
-                {
-                  "cluster": "in.1090",
-                  "destination_ip_list": [
-                    "10.1.1.0/32"
-                  ]
-                }
-              ]
-            }
-          }
-        }
-      ],
-      "bind_to_port": false
-    },
-    {
       "address": "tcp://0.0.0.0:80",
       "filters": [
         {
@@ -226,7 +157,97 @@
       "bind_to_port": false
     },
     {
-      "address": "tcp://0.0.0.0:90",
+      "address": "tcp://10.1.0.0:90",
+      "filters": [
+        {
+          "type": "read",
+          "name": "tcp_proxy",
+          "config": {
+            "stat_prefix": "tcp",
+            "route_config": {
+              "routes": [
+                {
+                  "cluster": "out.hello.default.svc.cluster.local|custom",
+                  "destination_ip_list": [
+                    "10.1.0.0/32"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "bind_to_port": false
+    },
+    {
+      "address": "tcp://10.1.1.0:1081",
+      "filters": [
+        {
+          "type": "read",
+          "name": "http_connection_manager",
+          "config": {
+            "codec_type": "auto",
+            "stat_prefix": "http",
+            "route_config": {
+              "virtual_hosts": [
+                {
+                  "name": "hello.default.svc.cluster.local|http-status",
+                  "domains": [
+                    "hello:81",
+                    "hello.default:81",
+                    "hello.default.svc:81",
+                    "hello.default.svc.cluster:81",
+                    "hello.default.svc.cluster.local:81",
+                    "10.1.0.0:81",
+                    "10.1.1.0:1081"
+                  ],
+                  "routes": [
+                    {
+                      "prefix": "/",
+                      "cluster": "in.1081",
+                      "opaque_config": {
+                        "mixer_control": "on",
+                        "mixer_forward": "off"
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            "filters": [
+              {
+                "type": "decoder",
+                "name": "mixer",
+                "config": {
+                  "mixer_server": "mixer:9091",
+                  "mixer_attributes": {
+                    "target.service": "hello.default.svc.cluster.local",
+                    "target.uid": "10.1.1.0"
+                  },
+                  "forward_attributes": {
+                    "source.service": "hello.default.svc.cluster.local",
+                    "source.uid": "10.1.1.0"
+                  }
+                }
+              },
+              {
+                "type": "decoder",
+                "name": "router",
+                "config": {}
+              }
+            ],
+            "access_log": [
+              {
+                "path": "/dev/stdout"
+              }
+            ]
+          }
+        }
+      ],
+      "bind_to_port": false
+    },
+    {
+      "address": "tcp://10.1.1.0:1090",
       "filters": [
         {
           "type": "read",
@@ -238,15 +259,105 @@
                 {
                   "cluster": "in.1090",
                   "destination_ip_list": [
-                    "10.1.0.0/32"
+                    "10.1.1.0/32"
                   ]
-                },
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "bind_to_port": false
+    },
+    {
+      "address": "tcp://10.1.1.0:80",
+      "filters": [
+        {
+          "type": "read",
+          "name": "http_connection_manager",
+          "config": {
+            "codec_type": "auto",
+            "stat_prefix": "http",
+            "route_config": {
+              "virtual_hosts": [
+                {
+                  "name": "hello.default.svc.cluster.local|http",
+                  "domains": [
+                    "hello:80",
+                    "hello",
+                    "hello.default:80",
+                    "hello.default",
+                    "hello.default.svc:80",
+                    "hello.default.svc",
+                    "hello.default.svc.cluster:80",
+                    "hello.default.svc.cluster",
+                    "hello.default.svc.cluster.local:80",
+                    "hello.default.svc.cluster.local",
+                    "10.1.0.0:80",
+                    "10.1.0.0",
+                    "10.1.1.0:80",
+                    "10.1.1.0"
+                  ],
+                  "routes": [
+                    {
+                      "prefix": "/",
+                      "cluster": "in.80",
+                      "opaque_config": {
+                        "mixer_control": "on",
+                        "mixer_forward": "off"
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            "filters": [
+              {
+                "type": "decoder",
+                "name": "mixer",
+                "config": {
+                  "mixer_server": "mixer:9091",
+                  "mixer_attributes": {
+                    "target.service": "hello.default.svc.cluster.local",
+                    "target.uid": "10.1.1.0"
+                  },
+                  "forward_attributes": {
+                    "source.service": "hello.default.svc.cluster.local",
+                    "source.uid": "10.1.1.0"
+                  }
+                }
+              },
+              {
+                "type": "decoder",
+                "name": "router",
+                "config": {}
+              }
+            ],
+            "access_log": [
+              {
+                "path": "/dev/stdout"
+              }
+            ]
+          }
+        }
+      ],
+      "bind_to_port": false
+    },
+    {
+      "address": "tcp://10.2.0.0:90",
+      "filters": [
+        {
+          "type": "read",
+          "name": "tcp_proxy",
+          "config": {
+            "stat_prefix": "tcp",
+            "route_config": {
+              "routes": [
                 {
                   "cluster": "out.world.default.svc.cluster.local|custom",
                   "destination_ip_list": [
                     "10.2.0.0/32"
-                  ],
-                  "destination_ports": "90"
+                  ]
                 }
               ]
             }
@@ -300,6 +411,13 @@
             "url": "tcp://127.0.0.1:80"
           }
         ]
+      },
+      {
+        "name": "out.hello.default.svc.cluster.local|custom",
+        "service_name": "hello.default.svc.cluster.local|custom",
+        "connect_timeout_ms": 1000,
+        "type": "sds",
+        "lb_type": "round_robin"
       },
       {
         "name": "out.world.default.svc.cluster.local|custom",

--- a/proxy/envoy/testdata/envoy-v0.json.golden
+++ b/proxy/envoy/testdata/envoy-v0.json.golden
@@ -1,75 +1,6 @@
 {
   "listeners": [
     {
-      "address": "tcp://0.0.0.0:1081",
-      "filters": [
-        {
-          "type": "read",
-          "name": "http_connection_manager",
-          "config": {
-            "codec_type": "auto",
-            "stat_prefix": "http",
-            "rds": {
-              "cluster": "rds",
-              "route_config_name": "1081",
-              "refresh_delay_ms": 1000
-            },
-            "filters": [
-              {
-                "type": "decoder",
-                "name": "mixer",
-                "config": {
-                  "mixer_server": "mixer:9091",
-                  "mixer_attributes": {
-                    "target.service": "hello.default.svc.cluster.local",
-                    "target.uid": "10.1.1.0"
-                  },
-                  "forward_attributes": {
-                    "source.service": "hello.default.svc.cluster.local",
-                    "source.uid": "10.1.1.0"
-                  }
-                }
-              },
-              {
-                "type": "decoder",
-                "name": "router",
-                "config": {}
-              }
-            ],
-            "access_log": [
-              {
-                "path": "/dev/stdout"
-              }
-            ]
-          }
-        }
-      ],
-      "bind_to_port": false
-    },
-    {
-      "address": "tcp://0.0.0.0:1090",
-      "filters": [
-        {
-          "type": "read",
-          "name": "tcp_proxy",
-          "config": {
-            "stat_prefix": "tcp",
-            "route_config": {
-              "routes": [
-                {
-                  "cluster": "in.1090",
-                  "destination_ip_list": [
-                    "10.1.1.0/32"
-                  ]
-                }
-              ]
-            }
-          }
-        }
-      ],
-      "bind_to_port": false
-    },
-    {
       "address": "tcp://0.0.0.0:80",
       "filters": [
         {
@@ -162,7 +93,97 @@
       "bind_to_port": false
     },
     {
-      "address": "tcp://0.0.0.0:90",
+      "address": "tcp://10.1.0.0:90",
+      "filters": [
+        {
+          "type": "read",
+          "name": "tcp_proxy",
+          "config": {
+            "stat_prefix": "tcp",
+            "route_config": {
+              "routes": [
+                {
+                  "cluster": "out.hello.default.svc.cluster.local|custom",
+                  "destination_ip_list": [
+                    "10.1.0.0/32"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "bind_to_port": false
+    },
+    {
+      "address": "tcp://10.1.1.0:1081",
+      "filters": [
+        {
+          "type": "read",
+          "name": "http_connection_manager",
+          "config": {
+            "codec_type": "auto",
+            "stat_prefix": "http",
+            "route_config": {
+              "virtual_hosts": [
+                {
+                  "name": "hello.default.svc.cluster.local|http-status",
+                  "domains": [
+                    "hello:81",
+                    "hello.default:81",
+                    "hello.default.svc:81",
+                    "hello.default.svc.cluster:81",
+                    "hello.default.svc.cluster.local:81",
+                    "10.1.0.0:81",
+                    "10.1.1.0:1081"
+                  ],
+                  "routes": [
+                    {
+                      "prefix": "/",
+                      "cluster": "in.1081",
+                      "opaque_config": {
+                        "mixer_control": "on",
+                        "mixer_forward": "off"
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            "filters": [
+              {
+                "type": "decoder",
+                "name": "mixer",
+                "config": {
+                  "mixer_server": "mixer:9091",
+                  "mixer_attributes": {
+                    "target.service": "hello.default.svc.cluster.local",
+                    "target.uid": "10.1.1.0"
+                  },
+                  "forward_attributes": {
+                    "source.service": "hello.default.svc.cluster.local",
+                    "source.uid": "10.1.1.0"
+                  }
+                }
+              },
+              {
+                "type": "decoder",
+                "name": "router",
+                "config": {}
+              }
+            ],
+            "access_log": [
+              {
+                "path": "/dev/stdout"
+              }
+            ]
+          }
+        }
+      ],
+      "bind_to_port": false
+    },
+    {
+      "address": "tcp://10.1.1.0:1090",
       "filters": [
         {
           "type": "read",
@@ -174,15 +195,105 @@
                 {
                   "cluster": "in.1090",
                   "destination_ip_list": [
-                    "10.1.0.0/32"
+                    "10.1.1.0/32"
                   ]
-                },
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "bind_to_port": false
+    },
+    {
+      "address": "tcp://10.1.1.0:80",
+      "filters": [
+        {
+          "type": "read",
+          "name": "http_connection_manager",
+          "config": {
+            "codec_type": "auto",
+            "stat_prefix": "http",
+            "route_config": {
+              "virtual_hosts": [
+                {
+                  "name": "hello.default.svc.cluster.local|http",
+                  "domains": [
+                    "hello:80",
+                    "hello",
+                    "hello.default:80",
+                    "hello.default",
+                    "hello.default.svc:80",
+                    "hello.default.svc",
+                    "hello.default.svc.cluster:80",
+                    "hello.default.svc.cluster",
+                    "hello.default.svc.cluster.local:80",
+                    "hello.default.svc.cluster.local",
+                    "10.1.0.0:80",
+                    "10.1.0.0",
+                    "10.1.1.0:80",
+                    "10.1.1.0"
+                  ],
+                  "routes": [
+                    {
+                      "prefix": "/",
+                      "cluster": "in.80",
+                      "opaque_config": {
+                        "mixer_control": "on",
+                        "mixer_forward": "off"
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            "filters": [
+              {
+                "type": "decoder",
+                "name": "mixer",
+                "config": {
+                  "mixer_server": "mixer:9091",
+                  "mixer_attributes": {
+                    "target.service": "hello.default.svc.cluster.local",
+                    "target.uid": "10.1.1.0"
+                  },
+                  "forward_attributes": {
+                    "source.service": "hello.default.svc.cluster.local",
+                    "source.uid": "10.1.1.0"
+                  }
+                }
+              },
+              {
+                "type": "decoder",
+                "name": "router",
+                "config": {}
+              }
+            ],
+            "access_log": [
+              {
+                "path": "/dev/stdout"
+              }
+            ]
+          }
+        }
+      ],
+      "bind_to_port": false
+    },
+    {
+      "address": "tcp://10.2.0.0:90",
+      "filters": [
+        {
+          "type": "read",
+          "name": "tcp_proxy",
+          "config": {
+            "stat_prefix": "tcp",
+            "route_config": {
+              "routes": [
                 {
                   "cluster": "out.world.default.svc.cluster.local|custom",
                   "destination_ip_list": [
                     "10.2.0.0/32"
-                  ],
-                  "destination_ports": "90"
+                  ]
                 }
               ]
             }
@@ -236,6 +347,13 @@
             "url": "tcp://127.0.0.1:80"
           }
         ]
+      },
+      {
+        "name": "out.hello.default.svc.cluster.local|custom",
+        "service_name": "hello.default.svc.cluster.local|custom",
+        "connect_timeout_ms": 1000,
+        "type": "sds",
+        "lb_type": "round_robin"
       },
       {
         "name": "out.world.default.svc.cluster.local|custom",

--- a/proxy/envoy/testdata/envoy-v1.json.golden
+++ b/proxy/envoy/testdata/envoy-v1.json.golden
@@ -1,75 +1,6 @@
 {
   "listeners": [
     {
-      "address": "tcp://0.0.0.0:1081",
-      "filters": [
-        {
-          "type": "read",
-          "name": "http_connection_manager",
-          "config": {
-            "codec_type": "auto",
-            "stat_prefix": "http",
-            "rds": {
-              "cluster": "rds",
-              "route_config_name": "1081",
-              "refresh_delay_ms": 1000
-            },
-            "filters": [
-              {
-                "type": "decoder",
-                "name": "mixer",
-                "config": {
-                  "mixer_server": "mixer:9091",
-                  "mixer_attributes": {
-                    "target.service": "hello.default.svc.cluster.local",
-                    "target.uid": "10.1.1.1"
-                  },
-                  "forward_attributes": {
-                    "source.service": "hello.default.svc.cluster.local",
-                    "source.uid": "10.1.1.1"
-                  }
-                }
-              },
-              {
-                "type": "decoder",
-                "name": "router",
-                "config": {}
-              }
-            ],
-            "access_log": [
-              {
-                "path": "/dev/stdout"
-              }
-            ]
-          }
-        }
-      ],
-      "bind_to_port": false
-    },
-    {
-      "address": "tcp://0.0.0.0:1090",
-      "filters": [
-        {
-          "type": "read",
-          "name": "tcp_proxy",
-          "config": {
-            "stat_prefix": "tcp",
-            "route_config": {
-              "routes": [
-                {
-                  "cluster": "in.1090",
-                  "destination_ip_list": [
-                    "10.1.1.1/32"
-                  ]
-                }
-              ]
-            }
-          }
-        }
-      ],
-      "bind_to_port": false
-    },
-    {
       "address": "tcp://0.0.0.0:80",
       "filters": [
         {
@@ -162,7 +93,97 @@
       "bind_to_port": false
     },
     {
-      "address": "tcp://0.0.0.0:90",
+      "address": "tcp://10.1.0.0:90",
+      "filters": [
+        {
+          "type": "read",
+          "name": "tcp_proxy",
+          "config": {
+            "stat_prefix": "tcp",
+            "route_config": {
+              "routes": [
+                {
+                  "cluster": "out.hello.default.svc.cluster.local|custom",
+                  "destination_ip_list": [
+                    "10.1.0.0/32"
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "bind_to_port": false
+    },
+    {
+      "address": "tcp://10.1.1.1:1081",
+      "filters": [
+        {
+          "type": "read",
+          "name": "http_connection_manager",
+          "config": {
+            "codec_type": "auto",
+            "stat_prefix": "http",
+            "route_config": {
+              "virtual_hosts": [
+                {
+                  "name": "hello.default.svc.cluster.local|http-status",
+                  "domains": [
+                    "hello:81",
+                    "hello.default:81",
+                    "hello.default.svc:81",
+                    "hello.default.svc.cluster:81",
+                    "hello.default.svc.cluster.local:81",
+                    "10.1.0.0:81",
+                    "10.1.1.1:1081"
+                  ],
+                  "routes": [
+                    {
+                      "prefix": "/",
+                      "cluster": "in.1081",
+                      "opaque_config": {
+                        "mixer_control": "on",
+                        "mixer_forward": "off"
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            "filters": [
+              {
+                "type": "decoder",
+                "name": "mixer",
+                "config": {
+                  "mixer_server": "mixer:9091",
+                  "mixer_attributes": {
+                    "target.service": "hello.default.svc.cluster.local",
+                    "target.uid": "10.1.1.1"
+                  },
+                  "forward_attributes": {
+                    "source.service": "hello.default.svc.cluster.local",
+                    "source.uid": "10.1.1.1"
+                  }
+                }
+              },
+              {
+                "type": "decoder",
+                "name": "router",
+                "config": {}
+              }
+            ],
+            "access_log": [
+              {
+                "path": "/dev/stdout"
+              }
+            ]
+          }
+        }
+      ],
+      "bind_to_port": false
+    },
+    {
+      "address": "tcp://10.1.1.1:1090",
       "filters": [
         {
           "type": "read",
@@ -174,15 +195,105 @@
                 {
                   "cluster": "in.1090",
                   "destination_ip_list": [
-                    "10.1.0.0/32"
+                    "10.1.1.1/32"
                   ]
-                },
+                }
+              ]
+            }
+          }
+        }
+      ],
+      "bind_to_port": false
+    },
+    {
+      "address": "tcp://10.1.1.1:80",
+      "filters": [
+        {
+          "type": "read",
+          "name": "http_connection_manager",
+          "config": {
+            "codec_type": "auto",
+            "stat_prefix": "http",
+            "route_config": {
+              "virtual_hosts": [
+                {
+                  "name": "hello.default.svc.cluster.local|http",
+                  "domains": [
+                    "hello:80",
+                    "hello",
+                    "hello.default:80",
+                    "hello.default",
+                    "hello.default.svc:80",
+                    "hello.default.svc",
+                    "hello.default.svc.cluster:80",
+                    "hello.default.svc.cluster",
+                    "hello.default.svc.cluster.local:80",
+                    "hello.default.svc.cluster.local",
+                    "10.1.0.0:80",
+                    "10.1.0.0",
+                    "10.1.1.1:80",
+                    "10.1.1.1"
+                  ],
+                  "routes": [
+                    {
+                      "prefix": "/",
+                      "cluster": "in.80",
+                      "opaque_config": {
+                        "mixer_control": "on",
+                        "mixer_forward": "off"
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            "filters": [
+              {
+                "type": "decoder",
+                "name": "mixer",
+                "config": {
+                  "mixer_server": "mixer:9091",
+                  "mixer_attributes": {
+                    "target.service": "hello.default.svc.cluster.local",
+                    "target.uid": "10.1.1.1"
+                  },
+                  "forward_attributes": {
+                    "source.service": "hello.default.svc.cluster.local",
+                    "source.uid": "10.1.1.1"
+                  }
+                }
+              },
+              {
+                "type": "decoder",
+                "name": "router",
+                "config": {}
+              }
+            ],
+            "access_log": [
+              {
+                "path": "/dev/stdout"
+              }
+            ]
+          }
+        }
+      ],
+      "bind_to_port": false
+    },
+    {
+      "address": "tcp://10.2.0.0:90",
+      "filters": [
+        {
+          "type": "read",
+          "name": "tcp_proxy",
+          "config": {
+            "stat_prefix": "tcp",
+            "route_config": {
+              "routes": [
                 {
                   "cluster": "out.world.default.svc.cluster.local|custom",
                   "destination_ip_list": [
                     "10.2.0.0/32"
-                  ],
-                  "destination_ports": "90"
+                  ]
                 }
               ]
             }
@@ -236,6 +347,13 @@
             "url": "tcp://127.0.0.1:80"
           }
         ]
+      },
+      {
+        "name": "out.hello.default.svc.cluster.local|custom",
+        "service_name": "hello.default.svc.cluster.local|custom",
+        "connect_timeout_ms": 1000,
+        "type": "sds",
+        "lb_type": "round_robin"
       },
       {
         "name": "out.world.default.svc.cluster.local|custom",

--- a/proxy/envoy/testdata/rds-fault.json.golden
+++ b/proxy/envoy/testdata/rds-fault.json.golden
@@ -14,18 +14,12 @@
      "hello.default.svc.cluster.local:80",
      "hello.default.svc.cluster.local",
      "10.1.0.0:80",
-     "10.1.0.0",
-     "10.1.1.0:80",
-     "10.1.1.0"
+     "10.1.0.0"
     ],
     "routes": [
      {
       "prefix": "/",
-      "cluster": "in.80",
-      "opaque_config": {
-       "mixer_control": "on",
-       "mixer_forward": "off"
-      }
+      "cluster": "out.hello.default.svc.cluster.local|http"
      }
     ]
    },

--- a/proxy/envoy/testdata/rds-timeout.json.golden
+++ b/proxy/envoy/testdata/rds-timeout.json.golden
@@ -14,18 +14,12 @@
      "hello.default.svc.cluster.local:80",
      "hello.default.svc.cluster.local",
      "10.1.0.0:80",
-     "10.1.0.0",
-     "10.1.1.0:80",
-     "10.1.1.0"
+     "10.1.0.0"
     ],
     "routes": [
      {
       "prefix": "/",
-      "cluster": "in.80",
-      "opaque_config": {
-       "mixer_control": "on",
-       "mixer_forward": "off"
-      }
+      "cluster": "out.hello.default.svc.cluster.local|http"
      }
     ]
    },

--- a/proxy/envoy/testdata/rds-v0.json.golden
+++ b/proxy/envoy/testdata/rds-v0.json.golden
@@ -14,18 +14,12 @@
      "hello.default.svc.cluster.local:80",
      "hello.default.svc.cluster.local",
      "10.1.0.0:80",
-     "10.1.0.0",
-     "10.1.1.0:80",
-     "10.1.1.0"
+     "10.1.0.0"
     ],
     "routes": [
      {
       "prefix": "/",
-      "cluster": "in.80",
-      "opaque_config": {
-       "mixer_control": "on",
-       "mixer_forward": "off"
-      }
+      "cluster": "out.hello.default.svc.cluster.local|http"
      }
     ]
    },

--- a/proxy/envoy/testdata/rds-v1.json.golden
+++ b/proxy/envoy/testdata/rds-v1.json.golden
@@ -14,18 +14,12 @@
      "hello.default.svc.cluster.local:80",
      "hello.default.svc.cluster.local",
      "10.1.0.0:80",
-     "10.1.0.0",
-     "10.1.1.1:80",
-     "10.1.1.1"
+     "10.1.0.0"
     ],
     "routes": [
      {
       "prefix": "/",
-      "cluster": "in.80",
-      "opaque_config": {
-       "mixer_control": "on",
-       "mixer_forward": "off"
-      }
+      "cluster": "out.hello.default.svc.cluster.local|http"
      }
     ]
    },

--- a/proxy/envoy/testdata/rds-weighted.json.golden
+++ b/proxy/envoy/testdata/rds-weighted.json.golden
@@ -14,18 +14,12 @@
      "hello.default.svc.cluster.local:80",
      "hello.default.svc.cluster.local",
      "10.1.0.0:80",
-     "10.1.0.0",
-     "10.1.1.0:80",
-     "10.1.1.0"
+     "10.1.0.0"
     ],
     "routes": [
      {
       "prefix": "/",
-      "cluster": "in.80",
-      "opaque_config": {
-       "mixer_control": "on",
-       "mixer_forward": "off"
-      }
+      "cluster": "out.hello.default.svc.cluster.local|http"
      }
     ]
    },

--- a/test/integration/driver.go
+++ b/test/integration/driver.go
@@ -139,11 +139,10 @@ func setup() {
 	pods = make(map[string]string)
 
 	// setup ingress resources
-	_, err = shell(fmt.Sprintf("kubectl -n %s create secret generic ingress "+
+	_, _ = shell(fmt.Sprintf("kubectl -n %s create secret generic ingress "+
 		"--from-file=tls.key=test/integration/cert.key "+
 		"--from-file=tls.crt=test/integration/cert.crt",
 		params.namespace))
-	check(err)
 
 	_, err = shell(fmt.Sprintf("kubectl -n %s apply -f test/integration/ingress.yaml", params.namespace))
 	check(err)


### PR DESCRIPTION
Change config generation to use three types of listeners:
1. inbound listeners, do not use CDS, RDS, SDS; bind to pod IP, port port pair.
2. outbound TCP listeners, use only SDS, bind to service IP, service port pair
3. outbound HTTP listeners, use CDS, RDS, SDS; bind to 0.0.0.0 and share ports

This PR touches a lot of cases, so please help reviewing this. This is needed to enable auth on inbound HTTP listeners.
