### PR TITLE
Enhanced ingress class annotation processing

### DIFF
--- a/platform/kube/controller.go
+++ b/platform/kube/controller.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/golang/glog"
@@ -39,19 +38,41 @@ import (
 
 const (
 	ingressClassAnnotation = "kubernetes.io/ingress.class"
-	ingressClass           = "istio"
+)
+
+// IngressSyncMode configures which ingress resources are synchronized by the controller.
+type IngressSyncMode int
+
+const (
+	// IngressOff mode - no ingress resources are synchronized.
+	// This mode is suitable for a Controller which does not run as an ingress controller.
+	IngressOff IngressSyncMode = iota
+
+	// IngressStrict mode - ingress resources are synchronized only if annotated with the configured ingress class.
+	// This mode is suitable for a Controller which is a running as a secondary ingress controller (e.g., in addition
+	// to a cloud-provided ingress controller).
+	IngressStrict
+
+	// IngressDefault mode - ingress resources are synchronized only if annotated with the configured ingress class,
+	// or not annotated with an ingress class at all.
+	// This mode is suitable for a Controller running as the cluster's default ingress controller, which is expected
+	// to also process ingress resources not annotated at all.
+	IngressDefault
 )
 
 // ControllerConfig stores the configurable attributes of a Controller.
 type ControllerConfig struct {
-	Namespace                string
-	ResyncPeriod             time.Duration
+	Namespace       string
+	ResyncPeriod    time.Duration
+	IngressSyncMode IngressSyncMode
+	IngressClass    string
 }
 
 // Controller is a collection of synchronized resource watchers
 // Caches are thread-safe
 type Controller struct {
 	client *Client
+	config ControllerConfig
 	queue  Queue
 
 	kinds     map[string]cacheHandler
@@ -72,6 +93,7 @@ func NewController(client *Client, config ControllerConfig) *Controller {
 	// Queue requires a time duration for a retry delay after a handler error
 	out := &Controller{
 		client: client,
+		config: config,
 		queue:  NewQueue(1 * time.Second),
 		kinds:  make(map[string]cacheHandler),
 	}
@@ -100,13 +122,15 @@ func NewController(client *Client, config ControllerConfig) *Controller {
 			return client.client.CoreV1().Pods(config.Namespace).Watch(opts)
 		}))
 
-	out.ingresses = out.createInformer(&v1beta1.Ingress{}, config.ResyncPeriod,
-		func(opts v1.ListOptions) (runtime.Object, error) {
-			return client.client.ExtensionsV1beta1().Ingresses(config.Namespace).List(opts)
-		},
-		func(opts v1.ListOptions) (watch.Interface, error) {
-			return client.client.ExtensionsV1beta1().Ingresses(config.Namespace).Watch(opts)
-		})
+	if config.IngressSyncMode != IngressOff {
+		out.ingresses = out.createInformer(&v1beta1.Ingress{}, config.ResyncPeriod,
+			func(opts v1.ListOptions) (runtime.Object, error) {
+				return client.client.ExtensionsV1beta1().Ingresses(config.Namespace).List(opts)
+			},
+			func(opts v1.ListOptions) (watch.Interface, error) {
+				return client.client.ExtensionsV1beta1().Ingresses(config.Namespace).Watch(opts)
+			})
+	}
 
 	// add stores for TPR kinds
 	for _, kind := range []string{IstioKind} {
@@ -217,9 +241,13 @@ func (c *Controller) appendTPRConfigHandler(k string, f func(model.Key, proto.Me
 }
 
 func (c *Controller) appendIngressConfigHandler(k string, f func(model.Key, proto.Message, model.Event)) error {
+	if c.config.IngressSyncMode == IngressOff {
+		return fmt.Errorf("cannot append ingress config handler: ingress resources synchronization is off")
+	}
+
 	c.ingresses.handler.append(func(obj interface{}, ev model.Event) error {
 		ingress := obj.(*v1beta1.Ingress)
-		if ingressIgnored(ingress) {
+		if !c.shouldProcessIngress(ingress) {
 			return nil
 		}
 
@@ -240,10 +268,14 @@ func (c *Controller) appendIngressConfigHandler(k string, f func(model.Key, prot
 func (c *Controller) HasSynced() bool {
 	if !c.services.informer.HasSynced() ||
 		!c.endpoints.informer.HasSynced() ||
-		!c.pods.informer.HasSynced() ||
-		!c.ingresses.informer.HasSynced() {
+		!c.pods.informer.HasSynced() {
 		return false
 	}
+
+	if c.config.IngressSyncMode != IngressOff && !c.ingresses.informer.HasSynced() {
+		return false
+	}
+
 	for kind, ctl := range c.kinds {
 		if !ctl.informer.HasSynced() {
 			glog.V(2).Infof("Controller %q is syncing...", kind)
@@ -259,10 +291,15 @@ func (c *Controller) Run(stop <-chan struct{}) {
 	go c.services.informer.Run(stop)
 	go c.endpoints.informer.Run(stop)
 	go c.pods.informer.Run(stop)
-	go c.ingresses.informer.Run(stop)
+
+	if c.config.IngressSyncMode != IngressOff {
+		go c.ingresses.informer.Run(stop)
+	}
+
 	for _, ctl := range c.kinds {
 		go ctl.informer.Run(stop)
 	}
+
 	<-stop
 	glog.V(2).Info("Controller terminated")
 }
@@ -318,6 +355,11 @@ func (c *Controller) getTPR(key model.Key) (proto.Message, bool) {
 }
 
 func (c *Controller) getIngress(key model.Key) (proto.Message, bool) {
+	if c.config.IngressSyncMode == IngressOff {
+		glog.Warningf("Cannot get ingress resource for key %v: ingress resources synchronization is off", key.String())
+		return nil, false
+	}
+
 	ingressName, _, _, err := decodeIngressRuleName(key.Name)
 	if err != nil {
 		glog.V(2).Infof("getIngress(%s) => error %v", key.String(), err)
@@ -335,7 +377,7 @@ func (c *Controller) getIngress(key model.Key) (proto.Message, bool) {
 	}
 
 	ingress := obj.(*v1beta1.Ingress)
-	if ingressIgnored(ingress) {
+	if !c.shouldProcessIngress(ingress) {
 		return nil, false
 	}
 
@@ -399,9 +441,15 @@ func (c *Controller) listTPRs(kind, namespace string) (map[model.Key]proto.Messa
 func (c *Controller) listIngresses(kind, namespace string) (map[model.Key]proto.Message, error) {
 	out := make(map[model.Key]proto.Message)
 
+	if c.config.IngressSyncMode == IngressOff {
+		glog.Warningf("Cannot list ingress resources: ingress resources synchronization is off")
+		return out, nil
+	}
+
 	for _, obj := range c.ingresses.informer.GetStore().List() {
 		ingress := obj.(*v1beta1.Ingress)
-		if !ingressIgnored(ingress) && (namespace == "" || ingress.GetObjectMeta().GetNamespace() == namespace) {
+		if c.shouldProcessIngress(ingress) &&
+			(namespace == "" || ingress.GetObjectMeta().GetNamespace() == namespace) {
 			ingressRules := convertIngress(*ingress, c.serviceByKey)
 			for key, message := range ingressRules {
 				out[key] = message
@@ -687,14 +735,24 @@ func (pc *PodCache) tagsByIP(addr string) (model.Tags, bool) {
 	return convertTags(item.(*v1.Pod).ObjectMeta), true
 }
 
-// ingressIgnored determine whether the given ingress resource should be ignored
-// by the given ingress controller, based on its ingress class annotation.
+// shouldProcessIngress determines whether the given ingress resource should be processed
+// by the Controller, based on its ingress class annotation.
 // See https://github.com/kubernetes/ingress/blob/master/examples/PREREQUISITES.md#ingress-class
-func ingressIgnored(ingress *v1beta1.Ingress) bool {
-	if ingress.Annotations == nil {
-		return false
+func (c *Controller) shouldProcessIngress(ingress *v1beta1.Ingress) bool {
+	class, exists := "", false
+	if ingress.Annotations != nil {
+		class, exists = ingress.Annotations[ingressClassAnnotation]
 	}
 
-	class, exists := ingress.Annotations[ingressClassAnnotation]
-	return exists && strings.ToLower(class) != ingressClass
+	switch c.config.IngressSyncMode {
+	case IngressOff:
+		return false
+	case IngressStrict:
+		return exists && class == c.config.IngressClass
+	case IngressDefault:
+		return !exists || class == c.config.IngressClass
+	default:
+		glog.Warningf("Invalid ingress synchronization mode: %v", c.config.IngressSyncMode)
+		return false
+	}
 }

--- a/platform/kube/controller_test.go
+++ b/platform/kube/controller_test.go
@@ -79,7 +79,7 @@ func TestController(t *testing.T) {
 	stop := make(chan struct{})
 	defer close(stop)
 
-	ctl := NewController(cl, ns, resync)
+	ctl := NewController(cl, ControllerConfig{Namespace: ns, ResyncPeriod: resync})
 	added, deleted := 0, 0
 	n := 5
 	err := ctl.AppendConfigHandler(mock.Kind, func(k model.Key, o proto.Message, ev model.Event) {
@@ -112,7 +112,7 @@ func TestControllerCacheFreshness(t *testing.T) {
 	ns := makeNamespace(cl.client, t)
 	defer deleteNamespace(cl.client, ns)
 	stop := make(chan struct{})
-	ctl := NewController(cl, ns, resync)
+	ctl := NewController(cl, ControllerConfig{Namespace: ns, ResyncPeriod: resync})
 
 	// test interface implementation
 	var _ model.Controller = ctl
@@ -182,7 +182,7 @@ func TestControllerClientSync(t *testing.T) {
 	}
 
 	// check in the controller cache
-	ctl := NewController(cl, ns, resync)
+	ctl := NewController(cl, ControllerConfig{Namespace: ns, ResyncPeriod: resync})
 	go ctl.Run(stop)
 	eventually(func() bool { return ctl.HasSynced() }, t)
 	os, _ := ctl.List(mock.Kind, ns)
@@ -254,7 +254,7 @@ func TestServices(t *testing.T) {
 	stop := make(chan struct{})
 	defer close(stop)
 
-	ctl := NewController(cl, ns, resync)
+	ctl := NewController(cl, ControllerConfig{Namespace: ns, ResyncPeriod: resync})
 	go ctl.Run(stop)
 
 	hostname := fmt.Sprintf("%s.%s.%s", testService, ns, ServiceSuffix)
@@ -312,7 +312,7 @@ func TestController_GetIstioServiceAccounts(t *testing.T) {
 	createPod(clientSet, map[string]string{"app": "prod-app"}, "pod4", "nsA", "acct3", t)
 	createPod(clientSet, map[string]string{"app": "prod-app"}, "pod5", "nsB", "acct4", t)
 
-	controller := NewController(&Client{client: clientSet}, "default", 100*time.Millisecond)
+	controller := NewController(&Client{client: clientSet}, ControllerConfig{Namespace: "default", ResyncPeriod: 100 * time.Millisecond})
 
 	createService(controller, "svc1", "nsA", map[string]string{"app": "prod-app"}, t)
 	createService(controller, "svc2", "nsA", map[string]string{"app": "staging-app"}, t)

--- a/platform/kube/controller_test.go
+++ b/platform/kube/controller_test.go
@@ -40,8 +40,8 @@ func TestIngressClass(t *testing.T) {
 	defer deleteNamespace(cl.client, ns)
 
 	cases := []struct {
-		ingressMode IngressSyncMode
-		ingressClass string
+		ingressMode   IngressSyncMode
+		ingressClass  string
 		shouldProcess bool
 	}{
 		{ingressMode: IngressDefault, ingressClass: "nginx", shouldProcess: false},
@@ -68,10 +68,10 @@ func TestIngressClass(t *testing.T) {
 		}
 
 		ctl := NewController(cl, ControllerConfig{
-			Namespace: ns,
-			ResyncPeriod: resync,
+			Namespace:       ns,
+			ResyncPeriod:    resync,
 			IngressSyncMode: c.ingressMode,
-			IngressClass: "istio",
+			IngressClass:    "istio",
 		})
 
 		if c.ingressClass != "" {
@@ -326,7 +326,10 @@ func TestController_GetIstioServiceAccounts(t *testing.T) {
 	createPod(clientSet, map[string]string{"app": "prod-app"}, "pod4", "nsA", "acct3", t)
 	createPod(clientSet, map[string]string{"app": "prod-app"}, "pod5", "nsB", "acct4", t)
 
-	controller := NewController(&Client{client: clientSet}, ControllerConfig{Namespace: "default", ResyncPeriod: 100 * time.Millisecond})
+	controller := NewController(&Client{client: clientSet}, ControllerConfig{
+		Namespace:    "default",
+		ResyncPeriod: 100 * time.Millisecond,
+	})
 
 	createService(controller, "svc1", "nsA", map[string]string{"app": "prod-app"}, t)
 	createService(controller, "svc2", "nsA", map[string]string{"app": "staging-app"}, t)


### PR DESCRIPTION
This PR adds two flags to the ingress controller (`manager ingress` command):
- `--ingress_class="istio"` - The class of ingress resources to be processed by the ingress controller.
- `--default_ingress_controller=true` - Specifies whether running as the cluster's default ingress controller, thereby processing unclassified ingress resources.

Implementation note: the user-facing `--default_ingress_controller` flag is represented internally as an `IngressSyncMode=Off|Strict|Default` enum parameter which is passed down into the `kube.Controller`. The `Off` value disables ingress watching/processing altogether, and is used by the `manager sidecar` and `manager discovery` commands.

Resolves #371