### PR TITLE
istioctl: add option to enable core dumps in injected runtime proxy

### DIFF
--- a/cmd/istioctl/inject.go
+++ b/cmd/istioctl/inject.go
@@ -36,6 +36,7 @@ var (
 	sidecarProxyPort int
 	runtimeVerbosity int
 	versionStr       string // override build version
+	enableCoreDump   bool
 
 	inFilename  string
 	outFilename string
@@ -99,6 +100,7 @@ Example usage:
 				SidecarProxyUID:  sidecarProxyUID,
 				SidecarProxyPort: sidecarProxyPort,
 				Version:          versionStr,
+				EnableCoreDump:   enableCoreDump,
 			}
 			return inject.IntoResourceFile(params, reader, writer)
 		},
@@ -126,5 +128,7 @@ func init() {
 		inject.DefaultSidecarProxyPort, "Sidecar proxy Port")
 	injectCmd.PersistentFlags().StringVar(&versionStr, "setVersionString",
 		"", "Override version info injected into resource")
+	injectCmd.PersistentFlags().BoolVar(&enableCoreDump, "coreDump",
+		true, "Enable/Disable core dumps in injected proxy")
 	cmd.RootCmd.AddCommand(injectCmd)
 }

--- a/cmd/istioctl/inject.go
+++ b/cmd/istioctl/inject.go
@@ -128,7 +128,14 @@ func init() {
 		inject.DefaultSidecarProxyPort, "Sidecar proxy Port")
 	injectCmd.PersistentFlags().StringVar(&versionStr, "setVersionString",
 		"", "Override version info injected into resource")
+
+	// Default --coreDump=true for pre-alpha development. Core dump
+	// settings (i.e. sysctl kernel.*) affect all pods in a node and
+	// require privileges. This option should only be used by the cluster
+	// admin (see https://kubernetes.io/docs/concepts/cluster-administration/sysctl-cluster/)
 	injectCmd.PersistentFlags().BoolVar(&enableCoreDump, "coreDump",
-		true, "Enable/Disable core dumps in injected proxy")
+		true, "Enable/Disable core dumps in injected proxy (--coreDump=true affects "+
+			"all pods in a node and should only be used the cluster admin)")
+
 	cmd.RootCmd.AddCommand(injectCmd)
 }

--- a/docker/prepare_proxy.sh
+++ b/docker/prepare_proxy.sh
@@ -44,8 +44,4 @@ iptables -t nat -A PREROUTING -p tcp -j REDIRECT --to-port ${ISTIO_PROXY_PORT}
 iptables -t nat -A OUTPUT -p tcp -j REDIRECT ! -s 127.0.0.1/32 \
   --to-port ${ISTIO_PROXY_PORT} -m owner '!' --uid-owner ${ISTIO_PROXY_UID}
 
-# Enable core dumps to writable directory
-sysctl -w  kernel.core_pattern=/tmp/core.%e.%p.%t
-
 exit 0
-

--- a/platform/kube/inject/inject_test.go
+++ b/platform/kube/inject/inject_test.go
@@ -38,21 +38,11 @@ func TestImageName(t *testing.T) {
 const unitTestTag = "unittest"
 
 func TestIntoResourceFile(t *testing.T) {
-	params := Params{
-
-		InitImage:        InitImageName(DefaultHub, unitTestTag),
-		RuntimeImage:     RuntimeImageName(DefaultHub, unitTestTag),
-		RuntimeVerbosity: DefaultRuntimeVerbosity,
-		ManagerAddr:      DefaultManagerAddr,
-		MixerAddr:        DefaultMixerAddr,
-		SidecarProxyUID:  DefaultSidecarProxyUID,
-		SidecarProxyPort: DefaultSidecarProxyPort,
-		Version:          "12345678",
-	}
 
 	cases := []struct {
-		in   string
-		want string
+		in             string
+		want           string
+		enableCoreDump bool
 	}{
 		{
 			in:   "testdata/hello.yaml",
@@ -82,9 +72,25 @@ func TestIntoResourceFile(t *testing.T) {
 			in:   "testdata/multi-init.yaml",
 			want: "testdata/multi-init.yaml.injected",
 		},
+		{
+			in:             "testdata/enable-core-dump.yaml",
+			want:           "testdata/enable-core-dump.yaml.injected",
+			enableCoreDump: true,
+		},
 	}
 
 	for _, c := range cases {
+		params := Params{
+			InitImage:        InitImageName(DefaultHub, unitTestTag),
+			RuntimeImage:     RuntimeImageName(DefaultHub, unitTestTag),
+			RuntimeVerbosity: DefaultRuntimeVerbosity,
+			ManagerAddr:      DefaultManagerAddr,
+			MixerAddr:        DefaultMixerAddr,
+			SidecarProxyUID:  DefaultSidecarProxyUID,
+			SidecarProxyPort: DefaultSidecarProxyPort,
+			Version:          "12345678",
+			EnableCoreDump:   c.enableCoreDump,
+		}
 		in, err := os.Open(c.in)
 		if err != nil {
 			t.Fatalf("Failed to open %q: %v", c.in, err)

--- a/platform/kube/inject/refresh.sh
+++ b/platform/kube/inject/refresh.sh
@@ -2,6 +2,10 @@
 
 workspace=$(bazel info workspace)
 for f in ${workspace}/platform/kube/inject/testdata/*.yaml; do
+    coreDump=false
+    if [ "$(basename ${f})" == "enable-core-dump.yaml" ]; then
+	coreDump=true
+    fi
     bazel run //cmd/istioctl:istioctl -- \
-          kube-inject -f ${f} -o ${f}.injected --setVersionString 12345678 --tag unittest
+          kube-inject -f ${f} -o ${f}.injected --setVersionString 12345678 --tag unittest --coreDump=${coreDump}
 done

--- a/platform/kube/inject/testdata/enable-core-dump.yaml
+++ b/platform/kube/inject/testdata/enable-core-dump.yaml
@@ -1,0 +1,19 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: hello
+spec:
+  replicas: 7
+  template:
+    metadata:
+      labels:
+        app: hello
+        tier: backend
+        track: stable
+    spec:
+      containers:
+        - name: hello
+          image: "gcr.io/google-samples/hello-go-gke:1.0"
+          ports:
+            - name: http
+              containerPort: 80

--- a/platform/kube/inject/testdata/enable-core-dump.yaml.injected
+++ b/platform/kube/inject/testdata/enable-core-dump.yaml.injected
@@ -1,0 +1,60 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  name: hello
+spec:
+  replicas: 7
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        alpha.istio.io/sidecar: injected
+        alpha.istio.io/version: "12345678"
+        pod.beta.kubernetes.io/init-containers: '[{"args":["-p","15001","-u","1337"],"image":"docker.io/istio/init:unittest","imagePullPolicy":"Always","name":"init","securityContext":{"capabilities":{"add":["NET_ADMIN"]}}},{"args":["-c","sysctl
+          -w kernel.core_pattern=/tmp/core.%e.%p.%t"],"command":["/bin/sh"],"image":"alpine","imagePullPolicy":"Always","name":"enable-core-dump","securityContext":{"privileged":true}}]'
+      creationTimestamp: null
+      labels:
+        app: hello
+        tier: backend
+        track: stable
+    spec:
+      containers:
+      - image: gcr.io/google-samples/hello-go-gke:1.0
+        name: hello
+        ports:
+        - containerPort: 80
+          name: http
+        resources: {}
+      - args:
+        - proxy
+        - sidecar
+        - -s
+        - istio-manager:8080
+        - -m
+        - istio-mixer:9091
+        - -n
+        - $(POD_NAMESPACE)
+        - -v
+        - "2"
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: docker.io/istio/runtime:unittest
+        imagePullPolicy: Always
+        name: proxy
+        resources: {}
+        securityContext:
+          runAsUser: 1337
+status: {}
+---


### PR DESCRIPTION
Enable core dumps in the runtime proxy for better always-on debugging
experience. "sysctl -w kernel.core_pattern=/tmp/core.%e.%p.%t"
requires additional privileges so use separate init-container to avoid
leaking elevated privileges into non-debug files/images.

This commit adds the `--coreDump` flag to control whether core dumps
are enabled or not and defaults to true for pre-alpha development.