### PR TITLE
Rename CLI option for manager from --config to --meshConfig

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -179,7 +179,7 @@ func init() {
 		"Select a Kubernetes namespace for the controller loop ('' means all namespaces)")
 	rootCmd.PersistentFlags().DurationVar(&flags.resyncPeriod, "resync", 100*time.Millisecond,
 		"Controller resync interval")
-	rootCmd.PersistentFlags().StringVar(&flags.config, "config", "istio",
+	rootCmd.PersistentFlags().StringVar(&flags.config, "meshConfig", "istio",
 		fmt.Sprintf("ConfigMap name for Istio mesh configuration, key should be %q", cmd.ConfigMapKey))
 
 	discoveryCmd.PersistentFlags().IntVarP(&flags.sdsPort, "port", "p", 8080,


### PR DESCRIPTION
This is to stay consistent with the options for `istioctl kube-inject`