### PR TITLE
Let MANAGER_HUB and MANAGER_TAG env vars override defaults

### DIFF
--- a/cmd/istioctl/inject.go
+++ b/cmd/istioctl/inject.go
@@ -27,6 +27,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	DefaultHubEnvVar       = "MANAGER_HUB"
+	DefaultTagEnvVar       = "MANAGER_TAG"
+)
+
 var (
 	hub             string
 	tag             string
@@ -59,6 +64,12 @@ Example usage:
 		RunE: func(_ *cobra.Command, _ []string) (err error) {
 			if inFilename == "" {
 				return errors.New("filename not specified (see --filename or -f)")
+			}
+			if hub == "" {
+				return fmt.Errorf("specify --hub or define %v", DefaultHubEnvVar)
+			}
+			if tag == "" {
+				return fmt.Errorf("specify --tag or define %v", DefaultTagEnvVar)
 			}
 			var reader io.Reader
 			if inFilename == "-" {
@@ -107,20 +118,10 @@ Example usage:
 )
 
 func init() {
-	defaultHub := os.Getenv(inject.DefaultHubEnvVar)
-	if defaultHub == "" {
-		defaultHub = inject.DefaultHub
-	}
 	injectCmd.PersistentFlags().StringVar(&hub, "hub",
-		defaultHub, "Docker hub")
-
-	defaultTag := os.Getenv(inject.DefaultTagEnvVar)
-	if defaultTag == "" {
-		defaultTag = inject.DefaultTag
-	}
+		os.Getenv(DefaultHubEnvVar), "Docker hub")
 	injectCmd.PersistentFlags().StringVar(&tag, "tag",
-		defaultTag, "Docker tag")
-
+		os.Getenv(DefaultTagEnvVar), "Docker tag")
 	injectCmd.PersistentFlags().StringVarP(&inFilename, "filename", "f",
 		"", "Input kubernetes resource filename")
 	injectCmd.PersistentFlags().StringVarP(&outFilename, "output", "o",

--- a/cmd/istioctl/inject.go
+++ b/cmd/istioctl/inject.go
@@ -28,9 +28,9 @@ import (
 )
 
 const (
-	// The environment variable that defaults the value of the --hub flag to istioctl kube-inject
+	// DefaultHubEnvVar is the environment variable that defaults the value of the --hub flag to istioctl kube-inject
 	DefaultHubEnvVar = "MANAGER_HUB"
-	// The environment variable that defaults the value of the --tag flag to istioctl kube-inject
+	// DefaultTagEnvVar is the environment variable that defaults the value of the --tag flag to istioctl kube-inject
 	DefaultTagEnvVar = "MANAGER_TAG"
 )
 

--- a/cmd/istioctl/inject.go
+++ b/cmd/istioctl/inject.go
@@ -28,8 +28,10 @@ import (
 )
 
 const (
-	DefaultHubEnvVar       = "MANAGER_HUB"
-	DefaultTagEnvVar       = "MANAGER_TAG"
+	// The environment variable that defaults the value of the --hub flag to istioctl kube-inject
+	DefaultHubEnvVar = "MANAGER_HUB"
+	// The environment variable that defaults the value of the --tag flag to istioctl kube-inject
+	DefaultTagEnvVar = "MANAGER_TAG"
 )
 
 var (

--- a/cmd/istioctl/inject.go
+++ b/cmd/istioctl/inject.go
@@ -107,10 +107,20 @@ Example usage:
 )
 
 func init() {
+	defaultHub := os.Getenv(inject.DefaultHubEnvVar)
+	if defaultHub == "" {
+		defaultHub = inject.DefaultHub
+	}
 	injectCmd.PersistentFlags().StringVar(&hub, "hub",
-		inject.DefaultHub, "Docker hub")
+		defaultHub, "Docker hub")
+
+	defaultTag := os.Getenv(inject.DefaultTagEnvVar)
+	if defaultTag == "" {
+		defaultTag = inject.DefaultTag
+	}
 	injectCmd.PersistentFlags().StringVar(&tag, "tag",
-		inject.DefaultTag, "Docker tag")
+		defaultTag, "Docker tag")
+
 	injectCmd.PersistentFlags().StringVarP(&inFilename, "filename", "f",
 		"", "Input kubernetes resource filename")
 	injectCmd.PersistentFlags().StringVarP(&outFilename, "output", "o",

--- a/platform/kube/inject/inject.go
+++ b/platform/kube/inject/inject.go
@@ -40,10 +40,6 @@ import (
 // Defaults values for injecting istio proxy into kubernetes
 // resources.
 const (
-	DefaultHubEnvVar       = "MANAGER_HUB"
-	DefaultHub             = "docker.io/istio"
-	DefaultTagEnvVar       = "MANAGER_TAG"
-	DefaultTag             = "2017-03-22-17.30.06"
 	DefaultSidecarProxyUID = int64(1337)
 	DefaultVerbosity       = 2
 )

--- a/platform/kube/inject/inject.go
+++ b/platform/kube/inject/inject.go
@@ -40,7 +40,9 @@ import (
 // Defaults values for injecting istio proxy into kubernetes
 // resources.
 const (
+	DefaultHubEnvVar       = "MANAGER_HUB"
 	DefaultHub             = "docker.io/istio"
+	DefaultTagEnvVar       = "MANAGER_TAG"
 	DefaultTag             = "2017-03-22-17.30.06"
 	DefaultSidecarProxyUID = int64(1337)
 	DefaultVerbosity       = 2

--- a/platform/kube/inject/inject_test.go
+++ b/platform/kube/inject/inject_test.go
@@ -38,6 +38,10 @@ func TestImageName(t *testing.T) {
 // Tag name should be kept in sync with value in platform/kube/inject/refresh.sh
 const unitTestTag = "unittest"
 
+// This is the hub to expect in platform/kube/inject/testdata/frontend.yaml.injected
+// and the other .injected "want" YAMLs
+const unitTestHub = "docker.io/istio"
+
 func TestIntoResourceFile(t *testing.T) {
 	cases := []struct {
 		authConfigPath string
@@ -113,8 +117,8 @@ func TestIntoResourceFile(t *testing.T) {
 		}
 
 		params := Params{
-			InitImage:       InitImageName(DefaultHub, unitTestTag),
-			ProxyImage:      ProxyImageName(DefaultHub, unitTestTag),
+			InitImage:       InitImageName(unitTestHub, unitTestTag),
+			ProxyImage:      ProxyImageName(unitTestHub, unitTestTag),
 			Verbosity:       DefaultVerbosity,
 			SidecarProxyUID: DefaultSidecarProxyUID,
 			Version:         "12345678",


### PR DESCRIPTION
Let MANAGER_HUB and MANAGER_TAG env vars override defaults in inject.go if present

These variables are defined in _istio/istio/istio.VERSION_.

See issue #469 