### PR TITLE
Fix loopback issue injecting istio proxy

### DIFF
--- a/docker/prepare_proxy.sh
+++ b/docker/prepare_proxy.sh
@@ -51,7 +51,7 @@ iptables -t nat -A PREROUTING -p tcp -j REDIRECT --to-port ${ISTIO_PROXY_PORT}
 iptables -t nat -A OUTPUT -p tcp -o lo -j REDIRECT \
   ! -d 127.0.0.1/32 --to-port ${ISTIO_PROXY_PORT}
 
-# 3. Locally generated traffic not sent explicitly to loopback IP
+# 3. Locally generated traffic not sent explicitly from loopback IP
 # (i.e. proxy aware) or not from the proxy itself is redirected proxy port.
 iptables -t nat -A OUTPUT -p tcp -j REDIRECT ! -s 127.0.0.1/32 \
   --to-port ${ISTIO_PROXY_PORT} -m owner '!' --uid-owner ${ISTIO_PROXY_UID}

--- a/docker/prepare_proxy.sh
+++ b/docker/prepare_proxy.sh
@@ -40,13 +40,19 @@ if [[ -z "${ISTIO_PROXY_PORT-}" ]] || [[ -z "${ISTIO_PROXY_UID-}" ]]; then
   exit 1
 fi
 
+# 1. External traffic is redirected to proxy port
 iptables -t nat -A PREROUTING -p tcp -j REDIRECT --to-port ${ISTIO_PROXY_PORT}
-# To make sure when pod A wants to talk to service A, which is backed by pod A,
-# the traffic is going through proxy twice, client-side and server-side.
-# lo traffic doesn't go through PREROUTING, so needed to be processed in OUTPUT.
-iptables -t nat -A OUTPUT -p tcp -j REDIRECT -o lo \
+
+# 2. Locally generated traffic sent on loopback interface (because traffic was
+# routed locally) and destination IP is not explicitly the loopback IP
+# (e.g. 172.17.0.2 and not 127.0.0.1) is redirected back to proxy port.
+# This include any proxy generated traffic which is necessary to make
+# (app => proxy => proxy => app) work when two apps are same pod.
+iptables -t nat -A OUTPUT -p tcp -o lo -j REDIRECT \
   ! -d 127.0.0.1/32 --to-port ${ISTIO_PROXY_PORT}
 
+# 3. Locally generated traffic not sent explicitly to loopback IP
+# (i.e. proxy aware) or not from the proxy itself is redirected proxy port.
 iptables -t nat -A OUTPUT -p tcp -j REDIRECT ! -s 127.0.0.1/32 \
   --to-port ${ISTIO_PROXY_PORT} -m owner '!' --uid-owner ${ISTIO_PROXY_UID}
 


### PR DESCRIPTION
Previously for loopback traffic the iptables rule routed it as:
app -> proxy -> app

This will route it as:
app -> proxy (client-side) -> proxy (server-side) -> app

So proxy can upgrade the protocol between proxies (e.g. HTTP/2, TLS)

cc @myidpt @kyessenov 

Closes #103 .
