### PR TITLE
Fix get_workspace_status for Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,6 +49,10 @@ def presubmit(gitUtils, bazel, utils) {
       bazel.fetch('-k //...')
       bazel.build('//...')
     }
+    stage('Build istioctl') {
+      def remotePath = gitUtils.artifactsPath('istioctl')
+      sh("bin/cross-compile-istioctl -p ${remotePath}")
+    }
     stage('Go Build') {
       sh('bin/init.sh')
     }
@@ -68,10 +72,6 @@ def presubmit(gitUtils, bazel, utils) {
         sh("bin/e2e.sh -tag ${env.GIT_SHA} -v 2")
       }
     }
-    stage('Build istioctl') {
-      def remotePath = gitUtils.artifactsPath('istioctl')
-      sh("bin/cross-compile-istioctl -p ${remotePath}")
-    }
   }
 }
 
@@ -80,14 +80,14 @@ def stablePresubmit(gitUtils, bazel, utils) {
     bazel.updateBazelRc()
     utils.initTestingCluster()
     sh('ln -s ~/.kube/config platform/kube/')
+    stage('Build istioctl') {
+      def remotePath = gitUtils.artifactsPath('istioctl')
+      sh("bin/cross-compile-istioctl -p ${remotePath}")
+    }
     stage('Integration Tests') {
       timeout(30) {
         sh("bin/e2e.sh -count 10 -debug -tag ${env.GIT_SHA} -v 2")
       }
-    }
-    stage('Build istioctl') {
-      def remotePath = gitUtils.artifactsPath('istioctl')
-      sh("bin/cross-compile-istioctl -p ${remotePath}")
     }
   }
 }
@@ -96,15 +96,15 @@ def stablePostsubmit(gitUtils, bazel, utils) {
   goBuildNode(gitUtils, 'istio.io/manager') {
     bazel.updateBazelRc()
     sh('touch platform/kube/config')
+    stage('Build istioctl') {
+      def remotePath = gitUtils.artifactsPath('istioctl')
+      sh("bin/cross-compile-istioctl -p ${remotePath}")
+    }
     stage('Docker Push') {
       def images = 'init,init_debug,app,app_debug,proxy,proxy_debug,manager,manager_debug'
       def tags = "${env.GIT_SHORT_SHA},\$(date +%Y-%m-%d-%H.%M.%S),latest"
       utils.publishDockerImagesToDockerHub(images, tags)
       utils.publishDockerImagesToContainerRegistry(images, tags, '', 'gcr.io/istio-io')
-    }
-    stage('Build istioctl') {
-      def remotePath = gitUtils.artifactsPath('istioctl')
-      sh("bin/cross-compile-istioctl -p ${remotePath}")
     }
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!groovy
 
-@Library('testutils@stable-96c1bdb')
+@Library('testutils@stable-70699be')
 
 import org.istio.testutils.Utilities
 import org.istio.testutils.GitUtilities

--- a/bin/get_workspace_status
+++ b/bin/get_workspace_status
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 BUILD_GIT_REVISION=$(git rev-parse --short HEAD 2> /dev/null)
+GIT_SHA="${BUILD_GIT_REVISION}"
 if [[  $? == 0 ]]; then
     git diff-index --quiet HEAD
     if [[  $? != 0 ]]; then
@@ -10,8 +11,25 @@ else
     BUILD_GIT_REVISION=unknown
 fi
 
-echo buildAppVersion    $(git describe 2> /dev/null || echo unknown)
+function get_branch() {
+    local branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null)"
+    local remote=''
+    if [[ "${branch}" == 'HEAD' ]]; then
+      remote="$(git remote | head -n 1)"
+      branch="$(git show-ref | grep "${GIT_SHA}" \
+        | grep remotes | grep -v HEAD | sed -e "s/.*remotes.${remote}.//")"
+    fi
+    if [[ -n "${branch}" ]]; then
+      echo "${branch}"
+    else
+      echo 'unknown'
+    fi
+}
+
+get_branch
+
+echo buildAppVersion    "$(git describe 2> /dev/null || echo unknown)"
 echo buildGitRevision   "${BUILD_GIT_REVISION}"
-echo buildGitBranch     $(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)
-echo buildUser          $(whoami)
-echo buildHost          $(hostname -f)
+echo buildGitBranch     "$(get_branch)"
+echo buildUser          "$(whoami)"
+echo buildHost          "$(hostname -f)"

--- a/bin/get_workspace_status
+++ b/bin/get_workspace_status
@@ -1,22 +1,11 @@
 #!/bin/bash
 
-BUILD_GIT_REVISION=$(git rev-parse --short HEAD 2> /dev/null)
-GIT_SHA="${BUILD_GIT_REVISION}"
-if [[  $? == 0 ]]; then
-    git diff-index --quiet HEAD
-    if [[  $? != 0 ]]; then
-        BUILD_GIT_REVISION=${BUILD_GIT_REVISION}"-dirty"
-    fi
-else
-    BUILD_GIT_REVISION=unknown
-fi
-
 function get_branch() {
     local branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null)"
     local remote=''
     if [[ "${branch}" == 'HEAD' ]]; then
       remote="$(git remote | head -n 1)"
-      branch="$(git show-ref | grep "${GIT_SHA}" \
+      branch="$(git show-ref | grep "${BUILD_GIT_REVISION}" \
         | grep remotes | grep -v HEAD | sed -e "s/.*remotes.${remote}.//")"
     fi
     if [[ -n "${branch}" ]]; then
@@ -26,10 +15,20 @@ function get_branch() {
     fi
 }
 
-get_branch
+BUILD_GIT_REVISION=$(git rev-parse --short HEAD 2> /dev/null)
+if [[  $? == 0 ]]; then
+    BRANCH="$(get_branch)"
+    git diff-index --quiet HEAD
+    if [[  $? != 0 ]]; then
+        BUILD_GIT_REVISION=${BUILD_GIT_REVISION}"-dirty"
+    fi
+else
+    BUILD_GIT_REVISION=unknown
+    BRANCH=unknown
+fi
 
 echo buildAppVersion    "$(git describe 2> /dev/null || echo unknown)"
 echo buildGitRevision   "${BUILD_GIT_REVISION}"
-echo buildGitBranch     "$(get_branch)"
+echo buildGitBranch     "${BRANCH}"
 echo buildUser          "$(whoami)"
 echo buildHost          "$(hostname -f)"


### PR DESCRIPTION
The builds done with Jenkins were marked as dirty. The reason was that we update the tools/bazel.rc with the content of tools/bazel.rc.jenkins. Version stable-70699be of fixes that. Update pipeline to build istioctl first.