### PR TITLE
Only using tag when explicity asked

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!groovy
 
-@Library('testutils@stable-70699be')
+@Library('testutils@stable-cd138c4')
 
 import org.istio.testutils.Utilities
 import org.istio.testutils.GitUtilities

--- a/bin/get_workspace_status
+++ b/bin/get_workspace_status
@@ -2,11 +2,10 @@
 
 function get_branch() {
     local branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null)"
-    local remote=''
     if [[ "${branch}" == 'HEAD' ]]; then
-      remote="$(git remote | head -n 1)"
-      branch="$(git show-ref | grep "${BUILD_GIT_REVISION}" \
-        | grep remotes | grep -v HEAD | sed -e "s/.*remotes.${remote}.//")"
+      branch="$(git show-ref | grep ${BUILD_GIT_REVISION}  \
+        | grep -oP "refs/remotes/.*/\K.*" | grep -v -i head)" \
+        || branch=''
     fi
     if [[ -n "${branch}" ]]; then
       echo "${branch}"


### PR DESCRIPTION
Jenkins was saving artifacts to a location using SHA or tag if tag was available. In https://github.com/istio/istio-testing/commit/cd138c4c8e915880eecb95d68950be171c477c0a, we are only using tag when specified. Using this version of library.

Tweaking get_workspace_status for branches.