### PR TITLE
pass quota_name property to mixer

### DIFF
--- a/proxy/envoy/policy.go
+++ b/proxy/envoy/policy.go
@@ -61,6 +61,7 @@ func insertMixerFilter(listeners []*Listener, instances []*model.ServiceInstance
 							"source.ip":  context.IPAddress,
 							"source.uid": context.UID,
 						},
+						QuotaName: "RequestCount",
 					},
 				}}, http.Filters...)
 			}

--- a/proxy/envoy/resources.go
+++ b/proxy/envoy/resources.go
@@ -131,6 +131,8 @@ type FilterMixerConfig struct {
 	// ForwardAttributes specifies the list of attribute keys and values that
 	// are forwarded as an HTTP header to the server side proxy
 	ForwardAttributes map[string]string `json:"forward_attributes,omitempty"`
+
+	QuotaName string `json:"quota_name,omitempty"`
 }
 
 // FilterFaultConfig definition


### PR DESCRIPTION
By passing the `quota_name` property to mixer, I was able to see rate limiting kick in when running the bookinfo demo. Unfortunately it didn't work quite as expected. It seemed that not only the service that was configured to rate limit (ratings), but also other services (for example, when I refreshed the UI, it said that "reviews are not available" which implies the review service also was rate limiting). After another refresh, there appeared some strange message on the screen about quota (unfortunately I didn't capture it), and then after that it seemed totally broken. The productpage service was returning an internal error:
```
INTERNAL:unable to resolve config: 1 error occurred:

* unresolved attribute target.service
```
Here is the short script to run the demo to test rate limiting:
```
# setup
cd istio
source ./istio.VERSION
kubectl apply -f ./kubernetes/istio-install
cd demos/apps/bookinfo
kubectl create -f <(istioctl kube-inject -f bookinfo.yaml)
export GATEWAY_URL=$(kubectl get po -l infra=istio-ingress-controller -o jsonpath={.items[0].status.hostIP}):$(kubectl get svc istio-ingress-controller -o jsonpath={.spec.ports[0].nodePort})
istioctl create -f route-rule-all-v1.yaml
istioctl replace -f route-rule-reviews-v3.yaml

# test ratelimit
kubectl apply -f ../../mixer-config-quota-bookinfo.yaml
while true; do curl -s -o /dev/null http://$GATEWAY_URL/productpage; done

# point browser to $GATEWAY_URL/productpage and instead of ratings (stars) you should see message "Ratings not available"
```