### PR TITLE
Fetch Istio auth secret from Ingress proxy when mutual TLS is enabled

### DIFF
--- a/proxy/envoy/config.go
+++ b/proxy/envoy/config.go
@@ -326,19 +326,6 @@ func buildOutboundHTTPRoutes(
 		}
 
 		clusters.setTimeout(mesh.ConnectTimeout)
-
-		// apply SSL context to outbound clusters for authentication policy
-		switch mesh.AuthPolicy {
-		case proxyconfig.ProxyMeshConfig_NONE:
-		case proxyconfig.ProxyMeshConfig_MUTUAL_TLS:
-			serviceAccounts := accounts.GetIstioServiceAccounts(service.Hostname, service.Ports.GetNames())
-			sslContext := buildClusterSSLContext(mesh.AuthCertsPath, serviceAccounts)
-			for _, cluster := range clusters {
-				cluster.SSLContext = sslContext
-			}
-		default:
-			glog.Warningf("Unknown auth policy: %v", mesh.AuthPolicy)
-		}
 	}
 
 	httpConfigs.normalize()


### PR DESCRIPTION
This is part 1 for enabling Istio Auth between the Ingress and other
proxies.