### PR TITLE
Add k8s auth plugins

### DIFF
--- a/model/BUILD
+++ b/model/BUILD
@@ -50,6 +50,9 @@ go_test(
         "@com_github_davecgh_go_spew//spew:go_default_library",
         "@com_github_golang_mock//gomock:go_default_library",
         "@com_github_golang_protobuf//proto:go_default_library",
+        "@com_github_golang_protobuf//ptypes:go_default_library",
+        "@com_github_golang_protobuf//ptypes/duration:go_default_library",
+        "@com_github_hashicorp_go_multierror//:go_default_library",
         "@io_istio_api//:go_default_library",
     ],
 )

--- a/platform/kube/BUILD
+++ b/platform/kube/BUILD
@@ -27,6 +27,8 @@ go_library(
         "@io_k8s_client_go//pkg/api:go_default_library",
         "@io_k8s_client_go//pkg/api/v1:go_default_library",
         "@io_k8s_client_go//pkg/apis/extensions/v1beta1:go_default_library",
+        "@io_k8s_client_go//plugin/pkg/client/auth/gcp:go_default_library",
+        "@io_k8s_client_go//plugin/pkg/client/auth/oidc:go_default_library",
         "@io_k8s_client_go//rest:go_default_library",
         "@io_k8s_client_go//tools/cache:go_default_library",
         "@io_k8s_client_go//tools/clientcmd:go_default_library",

--- a/platform/kube/client.go
+++ b/platform/kube/client.go
@@ -32,6 +32,10 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/pkg/api"
 	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
+	// import GKE cluster authentication plugin
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+	// import OIDC cluster authentication plugin, e.g. for Tectonic
+	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 


### PR DESCRIPTION
Add "gcp" and "oidc" auth plugins. Verified that "gcp" plugin works for GKE. We still want to use client certs for testing since bazel does not allow invoking random commands from tests.