### PR TITLE
e2e ingress status IP check

### DIFF
--- a/test/integration/ingress.go
+++ b/test/integration/ingress.go
@@ -121,7 +121,7 @@ func (t *ingress) run() error {
 	return nil
 }
 
-// ensure that an IPs/hostnames are in the ingress statuses
+// ensure that IPs/hostnames are in the ingress statuses
 func (t *ingress) checkIngressStatus() error {
 	ings, err := client.Extensions().Ingresses(t.Namespace).List(metav1.ListOptions{})
 	if err != nil {


### PR DESCRIPTION
Ensures ingress status is given an IP. Since we are running without `mesh.ingressService` set, the IP will be the node IP.