### PR TITLE
New ?codes= option to simulate HTTP errors from echo server

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,3 +1,15 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_prefix")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_prefix")
 
 go_prefix("istio.io/manager")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["config.pb.go"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_golang_protobuf//proto:go_default_library",
+        "@com_github_golang_protobuf//ptypes/any:go_default_library",
+        "@com_github_golang_protobuf//ptypes/duration:go_default_library",
+        "@com_github_golang_protobuf//ptypes/wrappers:go_default_library",
+    ],
+)

--- a/BUILD
+++ b/BUILD
@@ -1,15 +1,3 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_prefix")
 
 go_prefix("istio.io/manager")
-
-go_library(
-    name = "go_default_library",
-    srcs = ["config.pb.go"],
-    visibility = ["//visibility:public"],
-    deps = [
-        "@com_github_golang_protobuf//proto:go_default_library",
-        "@com_github_golang_protobuf//ptypes/any:go_default_library",
-        "@com_github_golang_protobuf//ptypes/duration:go_default_library",
-        "@com_github_golang_protobuf//ptypes/wrappers:go_default_library",
-    ],
-)

--- a/BUILD
+++ b/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_prefix")
+load("@io_bazel_rules_go//go:def.bzl", "go_prefix")
 
 go_prefix("istio.io/manager")
 

--- a/test/server/echo.go
+++ b/test/server/echo.go
@@ -65,7 +65,7 @@ type handler struct {
 // The chance of a particular flavor is ( slices / sum of slices ).
 type codeAndSlices struct {
 	httpResponseCode int
-	slices int
+	slices           int
 }
 
 func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -169,12 +169,12 @@ func setResponseFromCodes(request *http.Request, response http.ResponseWriter) e
 	}
 	slice := rand.Intn(totalSlices)
 
-    // What flavor is that slice?
-	responseCode := codes[len(codes)-1].httpResponseCode   // Assume the last slice
-    position := 0
+	// What flavor is that slice?
+	responseCode := codes[len(codes)-1].httpResponseCode // Assume the last slice
+	position := 0
 	for n, flavor := range codes {
 		if position > slice {
-			responseCode = codes[n-1].httpResponseCode    // No, use an earlier slice
+			responseCode = codes[n-1].httpResponseCode // No, use an earlier slice
 			break
 		}
 		position += flavor.slices
@@ -198,7 +198,7 @@ func validateCodes(codestrings string) ([]codeAndSlices, error) {
 	for i, codestring := range aCodestrings {
 		codeAndSlice, err := validateCodeAndSlices(codestring)
 		if err != nil {
-			return []codeAndSlices{ codeAndSlices { http.StatusBadRequest, 1 } }, err
+			return []codeAndSlices{{http.StatusBadRequest, 1}}, err
 		}
 		codes[i] = codeAndSlice
 	}
@@ -213,28 +213,28 @@ func validateCodeAndSlices(codecount string) (codeAndSlices, error) {
 
 	// Demand code or code:number
 	if len(flavor) == 0 || len(flavor) > 2 {
-		return codeAndSlices { http.StatusBadRequest, 9999 }, fmt.Errorf("invalid %q (want code or code:count)", codecount)
+		return codeAndSlices{http.StatusBadRequest, 9999}, fmt.Errorf("invalid %q (want code or code:count)", codecount)
 	}
 
 	n, err := strconv.Atoi(flavor[0])
 	if err != nil {
-		return codeAndSlices { http.StatusBadRequest, 9999 }, err
+		return codeAndSlices{http.StatusBadRequest, 9999}, err
 	}
 
 	if n < http.StatusOK || n >= 600 {
-		return codeAndSlices { http.StatusBadRequest, 9999 }, fmt.Errorf("invalid HTTP response code %v", n)
+		return codeAndSlices{http.StatusBadRequest, 9999}, fmt.Errorf("invalid HTTP response code %v", n)
 	}
 
 	count := 1
 	if len(flavor) > 1 {
 		count, err = strconv.Atoi(flavor[1])
 		if err != nil {
-			return codeAndSlices { http.StatusBadRequest, 9999 }, err
+			return codeAndSlices{http.StatusBadRequest, 9999}, err
 		}
 		if count < 0 {
-			return codeAndSlices { http.StatusBadRequest, 9999 }, fmt.Errorf("invalid count %v", count)
+			return codeAndSlices{http.StatusBadRequest, 9999}, fmt.Errorf("invalid count %v", count)
 		}
 	}
 
-	return codeAndSlices { n, count }, nil
+	return codeAndSlices{n, count}, nil
 }

--- a/test/server/echo.go
+++ b/test/server/echo.go
@@ -13,6 +13,14 @@
 // limitations under the License.
 
 // An example implementation of an echo backend.
+//
+// To test flaky HTTP service recovery, this backend has a special features.
+// If the "?codes=" query parameter is used it will return HTTP response codes other than 200
+// according to a probability distribution.
+// For example, ?codes=500:90,200:10 returns 500 90% of times and 200 10% of times
+// For example, ?codes=500:1,200:1 returns 500 50% of times and 200 50% of times
+// For example, ?codes=501:999,401:1 returns 500 99.9% of times and 401 0.1% of times.
+// For example, ?codes=500,200 returns 500 50% of times and 200 50% of times
 
 package main
 
@@ -20,6 +28,7 @@ import (
 	"bytes"
 	"fmt"
 	"log"
+	"math/rand"
 	"net"
 	"net/http"
 	"os"
@@ -51,8 +60,28 @@ type handler struct {
 	port int
 }
 
+// Imagine a pie of different flavors.
+// The flavors are the HTTP response codes.
+// The chance of a particular flavor is ( slices / sum of slices ).
+type codeAndSlices struct {
+	httpResponseCode int
+	slices int
+}
+
 func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	body := bytes.Buffer{}
+
+	if err := r.ParseForm(); err != nil {
+		body.WriteString("ParseForm() error: " + err.Error() + "\n")
+	}
+
+	// If the request has form ?codes=code[:chance][,code[:chance]]* return those codes, rather than 200
+	// For example, ?codes=500:1,200:1 returns 500 1/2 times and 200 1/2 times
+	// For example, ?codes=500:90,200:10 returns 500 90% of times and 200 10% of times
+	if err := setResponseFromCodes(r, w); err != nil {
+		body.WriteString("codes error: " + err.Error() + "\n")
+	}
+
 	body.WriteString("ServiceVersion=" + version + "\n")
 	body.WriteString("ServicePort=" + strconv.Itoa(h.port) + "\n")
 	body.WriteString("Method=" + r.Method + "\n")
@@ -65,8 +94,12 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			body.WriteString(fmt.Sprintf("%v=%v\n", name, h))
 		}
 	}
+
+	if hostname, err := os.Hostname(); err == nil {
+		body.WriteString(fmt.Sprintf("Hostname=%v\n", hostname))
+	}
+
 	w.Header().Set("Content-Type", "application/text")
-	w.WriteHeader(http.StatusOK)
 	if _, err := w.Write(body.Bytes()); err != nil {
 		log.Println(err.Error())
 	}
@@ -119,4 +152,89 @@ func main() {
 	sigs := make(chan os.Signal, 1)
 	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
 	<-sigs
+}
+
+func setResponseFromCodes(request *http.Request, response http.ResponseWriter) error {
+	responseCodes := request.FormValue("codes")
+
+	codes, err := validateCodes(responseCodes)
+	if err != nil {
+		return err
+	}
+
+	// Choose a random "slice" from a pie
+	var totalSlices = 0
+	for _, flavor := range codes {
+		totalSlices += flavor.slices
+	}
+	slice := rand.Intn(totalSlices)
+
+    // What flavor is that slice?
+	responseCode := codes[len(codes)-1].httpResponseCode   // Assume the last slice
+    position := 0
+	for n, flavor := range codes {
+		if position > slice {
+			responseCode = codes[n-1].httpResponseCode    // No, use an earlier slice
+			break
+		}
+		position += flavor.slices
+	}
+
+	response.WriteHeader(responseCode)
+	return nil
+}
+
+// codes must be comma-separated HTTP response code, colon, positive integer
+func validateCodes(codestrings string) ([]codeAndSlices, error) {
+
+	if codestrings == "" {
+		// Consider no codes to be "200:1" -- return HTTP 200 100% of the time.
+		codestrings = strconv.Itoa(http.StatusOK) + ":1"
+	}
+
+	aCodestrings := strings.Split(codestrings, ",")
+	codes := make([]codeAndSlices, len(aCodestrings))
+
+	for i, codestring := range aCodestrings {
+		codeAndSlice, err := validateCodeAndSlices(codestring)
+		if err != nil {
+			return []codeAndSlices{ codeAndSlices { http.StatusBadRequest, 1 } }, err
+		}
+		codes[i] = codeAndSlice
+	}
+
+	return codes, nil
+}
+
+// code must be HTTP response code
+func validateCodeAndSlices(codecount string) (codeAndSlices, error) {
+
+	flavor := strings.Split(codecount, ":")
+
+	// Demand code or code:number
+	if len(flavor) == 0 || len(flavor) > 2 {
+		return codeAndSlices { http.StatusBadRequest, 9999 }, fmt.Errorf("invalid %q (want code or code:count)", codecount)
+	}
+
+	n, err := strconv.Atoi(flavor[0])
+	if err != nil {
+		return codeAndSlices { http.StatusBadRequest, 9999 }, err
+	}
+
+	if n < http.StatusOK || n >= 600 {
+		return codeAndSlices { http.StatusBadRequest, 9999 }, fmt.Errorf("invalid HTTP response code %v", n)
+	}
+
+	count := 1
+	if len(flavor) > 1 {
+		count, err = strconv.Atoi(flavor[1])
+		if err != nil {
+			return codeAndSlices { http.StatusBadRequest, 9999 }, err
+		}
+		if count < 0 {
+			return codeAndSlices { http.StatusBadRequest, 9999 }, fmt.Errorf("invalid count %v", count)
+		}
+	}
+
+	return codeAndSlices { n, count }, nil
 }


### PR DESCRIPTION
This is a re-write of the ?codes= injection feature from last week.

The echo server output includes its hostname
If a request to the echo server HTTP includes ?codes=code[:chances],... the server might send a response other than HTTP 200.  This is for testing code that retries, but where we don't need to track the exact number of retries.

For example, ?codes=500:90,200:10 returns 500 90% of times and 200 10% of times
For example, ?codes=500:1,200:1 returns 500 50% of times and 200 50% of times
For example, ?codes=501:999,401:1 returns 500 99.9% of times and 401 0.1% of times.
For example, ?codes=500,200 returns 500 50% of times and 200 50% of times