### PR TITLE
e2e test for API server.

### DIFF
--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -102,6 +102,6 @@ func (api *API) Run() {
 // Shutdown calls `Shutdown(nil)` on the API server
 func (api *API) Shutdown(ctx context.Context) {
 	if api != nil && api.server != nil {
-		api.server.Shutdown(ctx)
+		api.server.Shutdown(ctx) // #nosec
 	}
 }

--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -1,6 +1,7 @@
 package apiserver
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -95,5 +96,12 @@ func (api *API) Run() {
 	glog.Infof("Starting api at %v", api.server.Addr)
 	if err := api.server.ListenAndServe(); err != nil {
 		glog.Warning(err)
+	}
+}
+
+// Shutdown calls `Shutdown(nil)` on the API server
+func (api *API) Shutdown(ctx context.Context) {
+	if api != nil && api.server != nil {
+		api.server.Shutdown(ctx)
 	}
 }

--- a/apiserver/apiserver.go
+++ b/apiserver/apiserver.go
@@ -102,6 +102,8 @@ func (api *API) Run() {
 // Shutdown calls `Shutdown(nil)` on the API server
 func (api *API) Shutdown(ctx context.Context) {
 	if api != nil && api.server != nil {
-		api.server.Shutdown(ctx) // #nosec
+		if err := api.server.Shutdown(ctx); err != nil {
+			glog.Warning(err)
+		}
 	}
 }

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -82,9 +82,6 @@ var (
 			}
 			if flags.controllerOptions.Namespace == "" {
 				flags.controllerOptions.Namespace = os.Getenv("POD_NAMESPACE")
-				if flags.controllerOptions.Namespace == "" {
-					return fmt.Errorf("export POD_NAMESPACE or supply --namespace flag")
-				}
 			}
 			glog.V(2).Infof("flags %s", spew.Sdump(flags))
 

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -58,6 +58,13 @@ var (
 		Short: "Istio Manager",
 		Long:  "Istio Manager provides management plane functionality to the Istio service mesh and Istio Mixer.",
 		PersistentPreRunE: func(*cobra.Command, []string) (err error) {
+			if flags.kubeconfig == "" {
+				if v := os.Getenv("KUBECONFIG"); v != "" {
+					glog.V(2).Infof("Setting configuration from KUBECONFIG environment variable")
+					flags.kubeconfig = v
+				}
+			}
+
 			client, err = kube.NewClient(flags.kubeconfig, model.IstioConfig)
 			if err != nil {
 				return multierror.Prefix(err, "failed to connect to Kubernetes API.")
@@ -75,6 +82,9 @@ var (
 			}
 			if flags.controllerOptions.Namespace == "" {
 				flags.controllerOptions.Namespace = os.Getenv("POD_NAMESPACE")
+				if flags.controllerOptions.Namespace == "" {
+					return fmt.Errorf("export POD_NAMESPACE or supply --namespace flag")
+				}
 			}
 			glog.V(2).Infof("flags %s", spew.Sdump(flags))
 

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "access.go",
+        "apiserver.go",
         "driver.go",
         "egress.go",
         "grpc.go",
@@ -15,6 +16,7 @@ go_library(
         "zipkin.go",
     ],
     deps = [
+        "//apiserver:go_default_library",
         "//cmd:go_default_library",
         "//model:go_default_library",
         "//platform/kube:go_default_library",

--- a/test/integration/apiserver.go
+++ b/test/integration/apiserver.go
@@ -264,7 +264,10 @@ func (r *apiServerTest) routeRuleCRUD() error {
 		// Attempt to delete rule, in case we created this and left it around due to a failure.
 		client := &net_http.Client{}
 		if req, err2 := net_http.NewRequest("DELETE", testURL, nil); err2 != nil {
-			client.Do(req) /* #nosec */
+			glog.V(2).Infof("Could not create request to clean up")
+		}
+		if _, err2 := client.Do(req); err2 != nil {
+			glog.V(2).Infof("Could not DELETE possible leftover Istio rule")
 		}
 	}
 

--- a/test/integration/apiserver.go
+++ b/test/integration/apiserver.go
@@ -1,0 +1,268 @@
+// Copyright 2017 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// API server tests
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	net_http "net/http"
+	"reflect"
+	"time"
+
+	multierror "github.com/hashicorp/go-multierror"
+
+	"istio.io/manager/apiserver"
+	"istio.io/manager/cmd"
+	"istio.io/manager/model"
+	"istio.io/manager/platform/kube"
+)
+
+type apiServerTest struct {
+	*infra
+
+	stopChannel chan struct{}
+	// readyChannel chan struct{}
+}
+
+type httpRequest struct {
+	method               string
+	url                  string
+	data                 interface{}
+	expectedResponseCode int
+	expectedBody         interface{}
+}
+
+const (
+//	routeRule = `{"type":"route-rule","name":"reviews-default","spec":{"destination":"reviews.default.svc.cluster.local",` +
+//		`"precedence":1,"route":[{"tags":{"version":"v1"},"weight":100}]}}`
+//	routeRule2 = `{"type":"route-rule","name":"reviews-default","spec":{"destination":"reviews.default.svc.cluster.local",` +
+//		`"precedence":1,"route":[{"tags":{"version":"v2"},"weight":100}]}}`
+//	invalidRule = `{"type":"route-rule","name":"reviews-invalid","spec":{"destination":"reviews.default.svc.cluster.local",` +
+//		`"precedence":1,"route":[{"tags":{"version":"v1"},"weight":999}]}}`
+)
+
+var (
+	jsonRule = map[string]interface{} {
+		"type": "route-rule",
+		"name": "reviews-default",
+		"spec": map[string]interface{} {
+			"destination": "reviews.default.svc.cluster.local",
+			"precedence": float64(1),
+			"route": []interface{} { map[string]interface{} {
+				"tags": map[string]interface{} {
+					"version": "v1",
+				},
+				"weight": float64(100),
+			} },
+		},
+	}
+
+	jsonRule2 = map[string]interface{} {
+		"type": "route-rule",
+		"name": "reviews-default",
+		"spec": map[string]interface{} {
+			"destination": "reviews.default.svc.cluster.local",
+			"precedence": float64(1),
+			"route": []interface{} { map[string]interface{} {
+				"tags": map[string]interface{} {
+					"version": "v2",
+				},
+				"weight": float64(100),
+			} },
+		},
+	}
+
+	jsonInvalidRule = map[string]interface{} {
+		"type": "route-rule",
+		"name": "reviews-default",
+		"spec": map[string]interface{} {
+			"destination": "reviews.default.svc.cluster.local",
+			"precedence": float64(1),
+			"route": []interface{} { map[string]interface{} {
+				"tags": map[string]interface{} {
+					"version": "v1",
+				},
+				"weight": float64(999),
+			} },
+		},
+	}
+
+)
+
+func (r *apiServerTest) String() string {
+	return "apiserver"
+}
+
+func (r *apiServerTest) setup() error {
+
+	// Start apiserver outside the cluster.
+
+	var err error
+	// receive mesh configuration
+	mesh, err := cmd.GetMeshConfig(istioClient.GetKubernetesClient(), r.Namespace, "istio")
+	if err != nil {
+		return fmt.Errorf("failed to retrieve mesh configuration.")
+		return multierror.Append(err, fmt.Errorf("failed to retrieve mesh configuration."))
+	}
+
+	controllerOptions := kube.ControllerOptions{}
+	controller := kube.NewController(istioClient, mesh, controllerOptions)
+	server := apiserver.NewAPI(apiserver.APIServiceOptions{
+		Version:  kube.IstioResourceVersion,
+		Port:     8081,
+		Registry: &model.IstioRegistry{ConfigRegistry: controller},
+	})
+	r.stopChannel = make(chan struct{})
+	go controller.Run(r.stopChannel)
+	go server.Run()
+
+	// Wait until apiserver is ready.  (As far as I can see there is no ready channel)
+	for i := 0; i < 10; i++ {
+		_, err := net_http.Get("http://localhost:8081/")
+		if err == nil {
+			break
+		}
+		time.Sleep(1 * time.Second)
+	}
+
+	return nil
+}
+
+func (r *apiServerTest) teardown() {
+	if r.stopChannel != nil {
+		close(r.stopChannel)
+	}
+}
+
+func (r *apiServerTest) run() error {
+	if err := r.routeRuleCRUD(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// routeRuleCRUD attempts to talk to the apiserver to Create, Retrieve, Update, and Delete a rule
+func (r *apiServerTest) routeRuleCRUD() error {
+	client := &net_http.Client{}
+
+	httpSequence := []httpRequest{
+		// Can't get before created
+		{
+			"GET", "http://localhost:8081/v1alpha1/config/route-rule/" + r.Namespace + "/reviews-default", "",
+			net_http.StatusNotFound, nil,
+		},
+		// Can create
+		{
+			"POST", "http://localhost:8081/v1alpha1/config/route-rule/" + r.Namespace + "/reviews-default", jsonRule,
+			net_http.StatusCreated, jsonRule,
+		},
+		// Can't create twice
+		{
+			// TODO should be StatusForbidden but the server is returning 500 (incorrectly?)
+			"POST", "http://localhost:8081/v1alpha1/config/route-rule/" + r.Namespace + "/reviews-default", jsonRule,
+			net_http.StatusInternalServerError, nil,
+		},
+		// Can't create invalid rules
+		{
+			// TODO should be net_http.StatusForbidden but the server is returning 500 (incorrectly?)
+			"POST", "http://localhost:8081/v1alpha1/config/route-rule/" + r.Namespace + "/reviews-invalid", jsonInvalidRule,
+			net_http.StatusInternalServerError, nil,
+		},
+		// Can get
+		{
+			"GET", "http://localhost:8081/v1alpha1/config/route-rule/" + r.Namespace + "/reviews-default", "",
+			net_http.StatusOK, jsonRule,
+		},
+		// Can update
+		{
+			"PUT", "http://localhost:8081/v1alpha1/config/route-rule/" + r.Namespace + "/reviews-default", jsonRule2,
+			net_http.StatusOK, jsonRule2,
+		},
+		// Can still GET after update
+		{
+			"GET", "http://localhost:8081/v1alpha1/config/route-rule/" + r.Namespace + "/reviews-default", "",
+			net_http.StatusOK, jsonRule2,
+		},
+		// Can delete
+		{
+			// Should (perhaps?) be StatusNoContent
+			"DELETE", "http://localhost:8081/v1alpha1/config/route-rule/" + r.Namespace + "/reviews-default", "",
+			net_http.StatusOK, nil,
+		},
+		// Can't delete twice
+		{
+			// Should be StatusNotFound
+			"DELETE", "http://localhost:8081/v1alpha1/config/route-rule/" + r.Namespace + "/reviews-default", "",
+			net_http.StatusInternalServerError, nil,
+		},
+	}
+
+	for _, hreq := range httpSequence {
+		var err error
+		var bytesToSend []byte
+		if hreq.data != nil {
+			bytesToSend, err = json.Marshal(hreq.data)
+			if err != nil {
+				return err
+			}
+		}
+		req, err := net_http.NewRequest(hreq.method, hreq.url, bytes.NewBuffer(bytesToSend))
+		if err != nil {
+			return err
+		}
+		req.Header.Add("Content-Type", "application/json")
+		resp, err := client.Do(req)
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != hreq.expectedResponseCode {
+			body, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				return err
+			}
+			return fmt.Errorf("%v to %q expected %v but got %v %q", hreq.method, hreq.url, hreq.expectedResponseCode, resp.StatusCode, body)
+		}
+		if hreq.expectedBody != nil {
+			body, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				return err
+			}
+
+			var jsonBody interface{}
+    		if err = json.Unmarshal([]byte(body), &jsonBody); err == nil {
+				if !reflect.DeepEqual(jsonBody, hreq.expectedBody) {
+					serializedExpectedBody, _ := json.Marshal(hreq.expectedBody)
+					if err != nil {
+						return err
+					}
+					return fmt.Errorf("%v to %q expected JSON body %v but got %v", hreq.method, hreq.url, string(serializedExpectedBody), string(body))
+				}
+    		} else {
+				// The returned data was not JSON, compare anyway
+				if !reflect.DeepEqual(body, hreq.expectedBody) {
+					return fmt.Errorf("%v to %q expected body %v but got %q", hreq.method, hreq.url, hreq.expectedBody, body)
+				}
+			}
+		}
+	}
+
+	return nil
+}
+

--- a/test/integration/apiserver.go
+++ b/test/integration/apiserver.go
@@ -259,12 +259,12 @@ func (r *apiServerTest) routeRuleCRUD() error {
 
 	err := verifySequence("CRUD", httpSequence)
 
-	// On error, clean up any rule we created that didn't get deleted by the final requests
+	// On error, clean up any rule we created that didn't get deleted by the final requests (in case count>1)
 	if err != nil {
 		// Attempt to delete rule, in case we created this and left it around due to a failure.
 		client := &net_http.Client{}
 		if req, err2 := net_http.NewRequest("DELETE", testURL, nil); err2 != nil {
-			client.Do(req) // #nosec
+			client.Do(req) /* #nosec */
 		}
 	}
 
@@ -360,7 +360,8 @@ func verifyRequest(hreq httpRequest, bytesToSend []byte, maxRetries int, rulenum
 				return nil
 			}
 
-			glog.V(2).Infof("Request for %v %v got expected status code but body did not match: %s\n", hreq.method, hreq.url, body)
+			glog.V(2).Infof("Request for %v %v got expected status code but body did not match: %s\n",
+				hreq.method, hreq.url, body)
 
 			serializedExpectedBody, err := json.Marshal(hreq.expectedBody)
 			if err != nil {

--- a/test/integration/apiserver.go
+++ b/test/integration/apiserver.go
@@ -46,6 +46,12 @@ type httpRequest struct {
 	data                 interface{}
 	expectedResponseCode int
 	expectedBody         interface{}
+
+	// These HTTP methods are not correct, but allowed before the rules database becomes consistent
+	retryOn map[int]bool
+
+	// These response values are not correct, but allowed before the rules database becomes consistent
+	retryIfMatch []interface{}
 }
 
 var (
@@ -93,6 +99,9 @@ var (
 			}},
 		},
 	}
+
+	// The URL we will use for talking directly to apiserver
+	testURL string
 )
 
 func (r *apiServerTest) String() string {
@@ -130,6 +139,8 @@ func (r *apiServerTest) setup() error {
 		time.Sleep(1 * time.Second)
 	}
 
+	testURL = "http://localhost:8081/v1alpha1/config/route-rule/" + r.Namespace + "/reviews-default"
+
 	return nil
 }
 
@@ -140,66 +151,107 @@ func (r *apiServerTest) teardown() {
 }
 
 func (r *apiServerTest) run() error {
-	return r.routeRuleCRUD()
+	if err := r.routeRuleInvalidDetected(); err != nil {
+		return err
+	}
+	if err := r.routeRuleCRUD(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *apiServerTest) routeRuleInvalidDetected() error {
+	httpSequence := []httpRequest{
+		// Can't create invalid rules
+		{
+			method: "POST", url: "http://localhost:8081/v1alpha1/config/route-rule/" + r.Namespace + "/reviews-invalid",
+			data:                 jsonInvalidRule,
+			expectedResponseCode: net_http.StatusInternalServerError,
+		},
+	}
+
+	return verifySequence(httpSequence)
 }
 
 // routeRuleCRUD attempts to talk to the apiserver to Create, Retrieve, Update, and Delete a rule
 func (r *apiServerTest) routeRuleCRUD() error {
-	client := &net_http.Client{}
 
+	// Run through the lifecycle of updating a rule, with errors, to verify the sequence works as expected.
 	httpSequence := []httpRequest{
-		// Can't get before created
+		// Step 0 Can't get before created
 		{
-			"GET", "http://localhost:8081/v1alpha1/config/route-rule/" + r.Namespace + "/reviews-default", "",
-			net_http.StatusNotFound, nil,
+			method: "GET", url: testURL,
+			expectedResponseCode: net_http.StatusNotFound,
 		},
-		// Can create
+		// Step 1 Can create
 		{
-			"POST", "http://localhost:8081/v1alpha1/config/route-rule/" + r.Namespace + "/reviews-default", jsonRule,
-			net_http.StatusCreated, jsonRule,
+			method: "POST", url: testURL,
+			data:                 jsonRule,
+			expectedResponseCode: net_http.StatusCreated,
+			expectedBody:         jsonRule,
+			// @@ retryOn:              map[int]bool{net_http.StatusInternalServerError: true},
 		},
-		// Can't create twice
+		// Step 2 Can't create twice
 		{
 			// TODO should be StatusForbidden but the server is returning 500 (incorrectly?)
-			"POST", "http://localhost:8081/v1alpha1/config/route-rule/" + r.Namespace + "/reviews-default", jsonRule,
-			net_http.StatusInternalServerError, nil,
+			method: "POST", url: testURL,
+			data:                 jsonRule,
+			expectedResponseCode: net_http.StatusInternalServerError,
 		},
-		// Can't create invalid rules
+		// Step 3 Can get
 		{
-			// TODO should be net_http.StatusForbidden but the server is returning 500 (incorrectly?)
-			"POST", "http://localhost:8081/v1alpha1/config/route-rule/" + r.Namespace + "/reviews-invalid", jsonInvalidRule,
-			net_http.StatusInternalServerError, nil,
+			method: "GET", url: testURL,
+			expectedResponseCode: net_http.StatusOK,
+			expectedBody:         jsonRule,
+			retryOn:              map[int]bool{net_http.StatusNotFound: true},
 		},
-		// Can get
+		// Step 4: Can update
 		{
-			"GET", "http://localhost:8081/v1alpha1/config/route-rule/" + r.Namespace + "/reviews-default", "",
-			net_http.StatusOK, jsonRule,
-		},
-		// Can update
-		{
-			"PUT", "http://localhost:8081/v1alpha1/config/route-rule/" + r.Namespace + "/reviews-default", jsonRule2,
-			net_http.StatusOK, jsonRule2,
+			method: "PUT", url: testURL,
+			data:                 jsonRule2,
+			expectedResponseCode: net_http.StatusOK,
+			expectedBody:         jsonRule2,
 		},
 		// Can still GET after update
 		{
-			"GET", "http://localhost:8081/v1alpha1/config/route-rule/" + r.Namespace + "/reviews-default", "",
-			net_http.StatusOK, jsonRule2,
+			method: "GET", url: testURL,
+			expectedResponseCode: net_http.StatusOK,
+			expectedBody:         jsonRule2,
+			retryOn:              map[int]bool{net_http.StatusNotFound: true},
+			retryIfMatch:         []interface{}{jsonRule},
 		},
 		// Can delete
 		{
-			// Should (perhaps?) be StatusNoContent
-			"DELETE", "http://localhost:8081/v1alpha1/config/route-rule/" + r.Namespace + "/reviews-default", "",
-			net_http.StatusOK, nil,
+			method: "DELETE", url: testURL,
+			expectedResponseCode: net_http.StatusOK, // Should (perhaps?) be StatusNoContent
+			retryOn:              map[int]bool{net_http.StatusNotFound: true},
 		},
 		// Can't delete twice
 		{
-			// Should be StatusNotFound
-			"DELETE", "http://localhost:8081/v1alpha1/config/route-rule/" + r.Namespace + "/reviews-default", "",
-			net_http.StatusInternalServerError, nil,
+			method: "DELETE", url: testURL,
+			expectedResponseCode: net_http.StatusInternalServerError, // Should be StatusNotFound
 		},
 	}
 
-	for _, hreq := range httpSequence {
+	err := verifySequence(httpSequence)
+
+	// On error, clean up any rule we created that didn't get deleted by the final requests
+	if err != nil {
+		// Attempt to delete rule, in case we created this and left it around due to a failure.
+		client := &net_http.Client{}
+		if req, err2 := net_http.NewRequest("DELETE", testURL, nil); err2 != nil {
+			client.Do(req) // #nosec
+		}
+	}
+
+	return err
+}
+
+// Verify a sequence of HTTP requests produce the expected responses
+func verifySequence(httpSequence []httpRequest) error {
+
+	for rulenum, hreq := range httpSequence {
+
 		var err error
 		var bytesToSend []byte
 		if hreq.data != nil {
@@ -208,49 +260,100 @@ func (r *apiServerTest) routeRuleCRUD() error {
 				return err
 			}
 		}
-		req, err := net_http.NewRequest(hreq.method, hreq.url, bytes.NewBuffer(bytesToSend))
-		if err != nil {
-			return err
-		}
-		req.Header.Add("Content-Type", "application/json")
-		resp, err := client.Do(req)
-		if err != nil {
-			return err
-		}
-		defer func() { _ = resp.Body.Close() }() // #nosec
-		if resp.StatusCode != hreq.expectedResponseCode {
-			body, err := ioutil.ReadAll(resp.Body)
-			if err != nil {
-				return err
-			}
-			return fmt.Errorf("%v to %q expected %v but got %v %q", hreq.method, hreq.url,
-				hreq.expectedResponseCode, resp.StatusCode, body)
-		}
-		if hreq.expectedBody != nil {
-			body, err := ioutil.ReadAll(resp.Body)
-			if err != nil {
-				return err
-			}
 
-			var jsonBody interface{}
-			if err = json.Unmarshal(body, &jsonBody); err == nil {
-				if !reflect.DeepEqual(jsonBody, hreq.expectedBody) {
-					serializedExpectedBody, _ := json.Marshal(hreq.expectedBody)
-					if err != nil {
-						return err
-					}
-					return fmt.Errorf("%v to %q expected JSON body %v but got %v", hreq.method, hreq.url,
-						string(serializedExpectedBody), string(body))
-				}
-			} else {
-				// The returned data was not JSON, compare anyway
-				if !reflect.DeepEqual(body, hreq.expectedBody) {
-					return fmt.Errorf("%v to %q expected body %v but got %q", hreq.method, hreq.url,
-						hreq.expectedBody, body)
-				}
-			}
+		// Verify a correct response comes back.  Retry up to 5 times in case data is initially incorrect
+		if err = verifyRequest(hreq, bytesToSend, 5, rulenum); err != nil {
+			return err
 		}
 	}
 
 	return nil
+}
+
+// Verify an HTTP requests produces the expected responses or a small number of the expected error responses
+func verifyRequest(hreq httpRequest, bytesToSend []byte, maxRetries int, rulenum int) error {
+	client := &net_http.Client{}
+
+	// Keep track if we need to retry before apiserver becomes consistent
+	retries := 0
+
+	for {
+		req, err := net_http.NewRequest(hreq.method, hreq.url, bytes.NewBuffer(bytesToSend))
+		if err != nil {
+			return err
+		}
+
+		if hreq.method == "POST" || hreq.method == "PUT" {
+			req.Header.Add("Content-Type", "application/json")
+		}
+
+		resp, err := client.Do(req)
+		if err != nil {
+			return err
+		}
+
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return err
+		}
+		if err = resp.Body.Close(); err != nil {
+			return err
+		}
+
+		// Did apiserver fail to return the expected response code?
+		if resp.StatusCode != hreq.expectedResponseCode {
+			// Did it return a code that could lead to a correct code after data becomes consistent?
+			if rt, ok := hreq.retryOn[resp.StatusCode]; !ok || !rt || retries > maxRetries {
+				return fmt.Errorf("%v to %q expected %v but got %v %q on step %v after %v attempts", hreq.method, hreq.url,
+					hreq.expectedResponseCode, resp.StatusCode, body, rulenum, retries)
+			}
+
+			// Give the system a moment after data-changing operations
+			time.Sleep(1 * time.Second)
+			fmt.Printf("@@@ ecs retrying %v %v because of status code\n", hreq.method, hreq.url)
+			retries++
+			continue
+		}
+
+		// Response code matches expectation.  We are done if we don't require a particular response body
+		if hreq.expectedBody == nil {
+			return nil
+		}
+
+		var jsonBody interface{}
+		if err = json.Unmarshal(body, &jsonBody); err == nil {
+			if reflect.DeepEqual(jsonBody, hreq.expectedBody) {
+				return nil
+			}
+
+			if retries >= maxRetries {
+				serializedExpectedBody, err := json.Marshal(hreq.expectedBody)
+				if err != nil {
+					return err
+				}
+				return fmt.Errorf("%v to %q expected JSON body %v but got %v on step %v after %v attempts", hreq.method, hreq.url,
+					string(serializedExpectedBody), string(body), rulenum, retries+1)
+			}
+
+			// Does the data match transient data we tolerate while waiting for consistency?
+			for retryIfMatch := range hreq.retryIfMatch {
+				if reflect.DeepEqual(jsonBody, retryIfMatch) {
+					// Give the system a moment after data-changing operations
+					time.Sleep(1 * time.Second)
+					retries++
+					fmt.Printf("@@@ ecs retrying %v %v because of body\n", hreq.method, hreq.url)
+					continue
+				}
+			}
+		} else {
+			// The returned data was not JSON
+			if retries >= maxRetries {
+				return fmt.Errorf("%v to %q expected body %v but got %q on step %v after %v attempts", hreq.method, hreq.url,
+					hreq.expectedBody, body, rulenum, retries+1)
+			}
+
+			retries++
+		}
+
+	} // end for (ever)
 }

--- a/test/integration/apiserver.go
+++ b/test/integration/apiserver.go
@@ -265,9 +265,10 @@ func (r *apiServerTest) routeRuleCRUD() error {
 		client := &net_http.Client{}
 		if req, err2 := net_http.NewRequest("DELETE", testURL, nil); err2 != nil {
 			glog.V(2).Infof("Could not create request to clean up")
-		}
-		if _, err2 := client.Do(req); err2 != nil {
-			glog.V(2).Infof("Could not DELETE possible leftover Istio rule")
+		} else {
+			if _, err2 := client.Do(req); err2 != nil {
+				glog.V(2).Infof("Could not DELETE possible leftover Istio rule")
+			}
 		}
 	}
 

--- a/test/integration/apiserver.go
+++ b/test/integration/apiserver.go
@@ -107,7 +107,6 @@ func (r *apiServerTest) setup() error {
 	// receive mesh configuration
 	mesh, err := cmd.GetMeshConfig(istioClient.GetKubernetesClient(), r.Namespace, "istio")
 	if err != nil {
-		return fmt.Errorf("failed to retrieve mesh configuration")
 		return multierror.Append(err, fmt.Errorf("failed to retrieve mesh configuration"))
 	}
 
@@ -246,7 +245,7 @@ func (r *apiServerTest) routeRuleCRUD() error {
 			} else {
 				// The returned data was not JSON, compare anyway
 				if !reflect.DeepEqual(body, hreq.expectedBody) {
-					return fmt.Errorf("%v to %q expected body %v but got %q", hreq.method, hreq.url, 
+					return fmt.Errorf("%v to %q expected body %v but got %q", hreq.method, hreq.url,
 						hreq.expectedBody, body)
 				}
 			}

--- a/test/integration/testdata/manager.yaml.tmpl
+++ b/test/integration/testdata/manager.yaml.tmpl
@@ -36,4 +36,16 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
+      - name: apiserver
+        image: {{.Hub}}/manager:{{.Tag}}
+        imagePullPolicy: Always
+        args: ["apiserver", "-v", "{{.Verbosity}}"]
+        ports:
+        - containerPort: 8081
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
 ---

--- a/test/integration/testdata/manager.yaml.tmpl
+++ b/test/integration/testdata/manager.yaml.tmpl
@@ -9,6 +9,8 @@ spec:
   ports:
   - port: 8080
     name: http-discovery
+  - port: 8081
+    name: http-apiserver
   selector:
     infra: manager
 ---


### PR DESCRIPTION
First part of fix for #660 

driver.go will issue requests against apiserver and verify the responses are as expected.

Allow API server to run outside K8s with KUBECONFIG env.  Test template should include apiserver container

A future PR will add additional tests so istioctl create/get/put/delete is used as well.

driver.go now takes an argument to just run one test.  I have been testing with

```
./test/integration/integration --tag vagrant_20170504_192054 -hub docker.io/esnible \
   --testtype "apiserver" --auth disable
```