### PR TITLE
Remove NodePort from Zipkin service definition in integration tests

### DIFF
--- a/test/integration/testdata/zipkin.yaml
+++ b/test/integration/testdata/zipkin.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     infra: zipkin
 spec:
-  type: NodePort
   ports:
   - port: 9411
     name: zipkin


### PR DESCRIPTION
Accidentally leftover from manual testing.