### PR TITLE
Usage for positional subcommands

### DIFF
--- a/cmd/istioctl/main.go
+++ b/cmd/istioctl/main.go
@@ -215,7 +215,7 @@ istioctl replace -f example-routing.yaml
 	}
 
 	getCmd = &cobra.Command{
-		Use:   "get",
+		Use:   "get <type> [<name>]",
 		Short: "Retrieve policies and rules",
 		Example: `
 # List all route rules
@@ -229,6 +229,7 @@ istioctl get route-rule productpage-default
 `,
 		RunE: func(c *cobra.Command, args []string) error {
 			if len(args) < 1 {
+				c.Println(c.UsageString())
 				return fmt.Errorf("specify the type of resource to get. Types are %v",
 					strings.Join(model.IstioConfig.Kinds(), ", "))
 			}
@@ -282,7 +283,7 @@ istioctl get route-rule productpage-default
 	}
 
 	deleteCmd = &cobra.Command{
-		Use:   "delete",
+		Use:   "delete <type> <name> [<name2> ... <nameN>]",
 		Short: "Delete policies or rules",
 		Example: `
 # Delete a rule using the definition in example-routing.yaml.

--- a/cmd/istioctl/mixer.go
+++ b/cmd/istioctl/mixer.go
@@ -99,7 +99,7 @@ Create and list Mixer rules in the configuration server.
 	}
 
 	mixerRuleCreateCmd = &cobra.Command{
-		Use:   "create",
+		Use:   "create <scope> <subject>",
 		Short: "Create Istio Mixer rules",
 		Example: `
 # Create a new Mixer rule for the given scope and subject.
@@ -117,7 +117,7 @@ istioctl mixer rule create global myservice.ns.svc.cluster.local -f mixer-rule.y
 		},
 	}
 	mixerRuleGetCmd = &cobra.Command{
-		Use:   "get",
+		Use:   "get <scope> <subject>",
 		Short: "Get Istio Mixer rules",
 		Long: `
 Get a Mixer rule for a given scope and subject.


### PR DESCRIPTION
Display the names of positional arguments when they are not specified.