### PR TITLE
istioctl: compile in default hub and tag versions for kube-inject

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,3 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_prefix")
 
 go_prefix("istio.io/manager")
+
+exports_files(["kube-inject-versions"], visibility = ["//visibility:public"])

--- a/bin/get_workspace_status
+++ b/bin/get_workspace_status
@@ -56,3 +56,8 @@ echo buildGitRevision   "${BUILD_GIT_REVISION}"
 echo buildGitBranch     "${BRANCH}"
 echo buildUser          "$(whoami)"
 echo buildHost          "$(hostname -f)"
+
+# Add kube-inject hub and tag key-values if present
+if [ -a ${ROOT}/kube-inject-versions ]; then
+    source ${ROOT}/kube-inject-versions
+fi

--- a/cmd/version/BUILD
+++ b/cmd/version/BUILD
@@ -4,5 +4,10 @@ go_library(
     name = "go_default_library",
     srcs = ["version.go"],
     visibility = ["//visibility:public"],
-    deps = ["@com_github_spf13_cobra//:go_default_library"],
+    deps = [
+        "@com_github_spf13_cobra//:go_default_library",
+    ],
+    data = [
+        "//:kube-inject-versions",
+    ]
 )

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -58,6 +58,11 @@ var (
 			fmt.Printf("GitBranch: %v\n", Info.GitBranch)
 			fmt.Printf("User: %v@%v\n", Info.User, Info.Host)
 			fmt.Printf("GolangVersion: %v\n", Info.GolangVersion)
+
+			if showKubeInjectInfo {
+				fmt.Printf("KubeInjectHub: %v\n", KubeInjectHub)
+				fmt.Printf("KubeInjectTag: %v\n", KubeInjectTag)
+			}
 		},
 	}
 )
@@ -69,6 +74,10 @@ func init() {
 	Info.User = buildUser
 	Info.Host = buildHost
 	Info.GolangVersion = runtime.Version()
+
+	VersionCmd.PersistentFlags().BoolVar(&showKubeInjectInfo, "kube-inject", false,
+		"Show kube-inject docker hub and tag info")
+	VersionCmd.PersistentFlags().MarkHidden("kube-inject") // nolint: errcheck
 }
 
 // Line combines version information into a single line
@@ -79,3 +88,17 @@ func Line() string {
 		Info.Version,
 		Info.GitRevision)
 }
+
+// Temporary workaround to make parameterize docker hub and tag for
+// kube-inject. Ideally this would be in cmd/istioctl/inject.go but
+// bazel's linkstamp feature requires all symbols to be in the same
+// golang package. This should go away once we switch over to
+// server-side kube-inject or k8s initializer.
+var (
+	showKubeInjectInfo bool
+
+	// KubeInjectHub is the linker specified docker hub for kube-inject.
+	KubeInjectHub string
+	// KubeInjectTag is the linker specified docker tag for kube-inject.
+	KubeInjectTag string
+)

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -77,7 +77,7 @@ func init() {
 
 	VersionCmd.PersistentFlags().BoolVar(&showKubeInjectInfo, "kube-inject", false,
 		"Show kube-inject docker hub and tag info")
-	VersionCmd.PersistentFlags().MarkHidden("kube-inject") // nolint: errcheck
+	VersionCmd.PersistentFlags().MarkHidden("kube-inject") // nolint: errcheck, gas
 }
 
 // Line combines version information into a single line

--- a/kube-inject-versions
+++ b/kube-inject-versions
@@ -1,0 +1,7 @@
+# Output image version for kube-inject in the form of key-value pairs
+# for consumption by bazel's linkstamp. See
+# github.com/bazelbuild/bazel/blob/master/tools/buildstamp/ for
+# details on the expected format and usage.
+
+echo KubeInjectHub docker.io
+echo KubeInjectTag 0.1.3

--- a/kube-inject-versions
+++ b/kube-inject-versions
@@ -3,5 +3,5 @@
 # github.com/bazelbuild/bazel/blob/master/tools/buildstamp/ for
 # details on the expected format and usage.
 
-echo KubeInjectHub docker.io
+echo KubeInjectHub docker.io/istio
 echo KubeInjectTag 0.1.3


### PR DESCRIPTION
Introduce a new file 'kube-inject-versions` to set the hardcoded
default hub and tag info for kube-inject. Order of precedence is flag,
env-var, and then built-in defaults.

Existing documentation that use `source istio.VERSION` should continue
to work until istio.VERSION is phased out.

For debug purposes `istioctl version --kube-inject` shows the default
docker hub and tag. This flag is hidden from help text to avoid
confusing users as kube-inject is planned to be moved server-side
post-alpha.