### PR TITLE
Make ingress election ID more unique

### DIFF
--- a/platform/kube/ingressstatus.go
+++ b/platform/kube/ingressstatus.go
@@ -28,6 +28,8 @@ import (
 	proxyconfig "istio.io/api/proxy/v1/config"
 )
 
+const ingressElectionID = "istio-ingress-controller-leader"
+
 // IngressStatusSyncer keeps the status IP in each Ingress resource updated
 type IngressStatusSyncer struct {
 	sync     status.Sync
@@ -68,7 +70,7 @@ func NewIngressStatusSyncer(mesh *proxyconfig.ProxyMeshConfig, client *Client,
 	sync := status.NewStatusSyncer(status.Config{
 		Client:              client.GetKubernetesClient(),
 		IngressLister:       store.IngressLister{Store: informer.GetStore()},
-		ElectionID:          "ingress-controller-leader", // TODO: configurable?
+		ElectionID:          ingressElectionID, // TODO: configurable?
 		PublishService:      publishService,
 		DefaultIngressClass: defaultIngressClass,
 		IngressClass:        ingressClass,


### PR DESCRIPTION
Make the ingress election ID more unique to reduce the chance of conflicts with other ingress controllers. Currently the election ID is the same as many other ingress controllers, which means the Istio ingress controller is competing with other controllers.