### PR TITLE
Allow istioctl version to work w/o --kube=false

### DIFF
--- a/platform/kube/client.go
+++ b/platform/kube/client.go
@@ -426,8 +426,8 @@ func (cl *Client) Request(namespace, service, method, path string, inBody []byte
 	// path is not. Short term workaround is to special case this
 	// behavior. Long term solution is to unify API scheme and server
 	// implementations.
-	if strings.HasPrefix(path, "config") {
-		absPath += "/" + IstioResourceVersion // manager api server patha
+	if strings.HasPrefix(path, "config") || strings.HasPrefix(path, "version") {
+		absPath += "/" + IstioResourceVersion // manager api server path
 	}
 
 	// API server resource path.


### PR DESCRIPTION
The `istioctl version` currently fails to print the remote apiserver version.  It prints the local version, then "Error: the server could not find the requested resource".  This fixes that bug.